### PR TITLE
JSON lexing was inconsistent with pygments

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -239,7 +239,7 @@ module Rouge
 
       state :object_key do
         mixin :whitespace
-        mixin :has_string
+        rule /"(\\\\|\\"|[^"])*"/, Name::Tag
         rule /:/, Punctuation, :object_val
         rule /}/, Error, :pop!
       end

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -215,6 +215,8 @@ module Rouge
         return 0.8 if text =~ /\A\s*{/m && text.lexes_cleanly?(self)
       end
 
+      string = /"(\\.|[^"])*"/
+
       state :root do
         mixin :whitespace
         # special case for empty objects
@@ -234,12 +236,12 @@ module Rouge
       end
 
       state :has_string do
-        rule /"(\\.|[^"])*"/, Str::Double
+        rule string, Str::Double
       end
 
       state :object_key do
         mixin :whitespace
-        rule /"(\\\\|\\"|[^"])*"/, Name::Tag
+        rule string, Name::Tag
         rule /:/, Punctuation, :object_val
         rule /}/, Error, :pop!
       end


### PR DESCRIPTION
Changes the json lexer to distinguish keys and values

I've been working on replacing pygments in a project with rouge: I noticed that the lexer in pygments marks json keys as tags, whereas rogue treats them as strings.  This made the output somewhat unclear when the values are also strings.