### PR TITLE
Add -v version flag

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -87,7 +87,7 @@ module Rouge
 
     def self.class_from_arg(arg)
       case arg
-      when 'version', '--version'
+      when 'version', '--version', '-v'
         Version
       when 'help'
         Help


### PR DESCRIPTION
Seeing as we have a `-h` flag to display help text I think it would make sense to also allow a `-v` flag to get the version.