### PR TITLE
Fix CSS class and ID regex

### DIFF
--- a/lib/rouge/lexers/slim.rb
+++ b/lib/rouge/lexers/slim.rb
@@ -152,8 +152,8 @@ module Rouge
       end
 
       state :css do
-        rule(/\.\w+/) { token Name::Class; goto :tag }
-        rule(/#\w+/) { token Name::Function; goto :tag }
+        rule(/\.-?[_a-zA-Z]+[\w-]*/) { token Name::Class; goto :tag }
+        rule(/#[a-zA-Z]+[\w-:.]*/) { token Name::Function; goto :tag }
       end
 
       state :html_attr do


### PR DESCRIPTION
The previous regex was too basic and ignoring common CSS characters like '-'. This new regex is based off of  http://stackoverflow.com/a/449000/625710 and http://stackoverflow.com/a/70586/625710