### PR TITLE
Fix 'empty range in char class'

### DIFF
--- a/lib/rouge/lexers/slim.rb
+++ b/lib/rouge/lexers/slim.rb
@@ -152,7 +152,7 @@ module Rouge
       end
 
       state :css do
-        rule(/\.-?[_a-zA-Z]+[\w-]*/) { token Name::Class; goto :tag }
+        rule(/\.-?[_a-zA-Z][\w-]*/) { token Name::Class; goto :tag }
         rule(/#[a-zA-Z][\w:-]*/) { token Name::Function; goto :tag }
       end
 

--- a/lib/rouge/lexers/slim.rb
+++ b/lib/rouge/lexers/slim.rb
@@ -153,7 +153,7 @@ module Rouge
 
       state :css do
         rule(/\.-?[_a-zA-Z]+[\w-]*/) { token Name::Class; goto :tag }
-        rule(/#[a-zA-Z]+[\w-:.]*/) { token Name::Function; goto :tag }
+        rule(/#[a-zA-Z]+[\w:.-]*/) { token Name::Function; goto :tag }
       end
 
       state :html_attr do

--- a/lib/rouge/lexers/slim.rb
+++ b/lib/rouge/lexers/slim.rb
@@ -153,7 +153,7 @@ module Rouge
 
       state :css do
         rule(/\.-?[_a-zA-Z]+[\w-]*/) { token Name::Class; goto :tag }
-        rule(/#[a-zA-Z]+[\w:.-]*/) { token Name::Function; goto :tag }
+        rule(/#[a-zA-Z][\w:-]*/) { token Name::Function; goto :tag }
       end
 
       state :html_attr do

--- a/lib/rouge/lexers/slim.rb
+++ b/lib/rouge/lexers/slim.rb
@@ -152,7 +152,7 @@ module Rouge
       end
 
       state :css do
-        rule(/\.-?[_a-zA-Z][\w-]*/) { token Name::Class; goto :tag }
+        rule(/\.[\w-]*/) { token Name::Class; goto :tag }
         rule(/#[a-zA-Z][\w:-]*/) { token Name::Function; goto :tag }
       end
 


### PR DESCRIPTION
The dash in the regex char set was interpreted as a range. Moving it to the end of the char set fixes the ambiguity.