### PR TITLE
Add support for lexing array literals in ObjectiveC

### DIFF
--- a/lib/rouge/demos/objective_c
+++ b/lib/rouge/demos/objective_c
@@ -10,3 +10,5 @@
 
 -(id)initWithAge:(int)age;
 @end
+
+NSArray *arrayLiteral = @[@"abc", @1];

--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -79,6 +79,7 @@ module Rouge
 
         rule /[?]/, Punctuation, :ternary
         rule /\[/,  Punctuation, :message
+        rule /@\[/, Punctuation, :array_literal
       end
 
       state :ternary do
@@ -113,6 +114,12 @@ module Rouge
         end
 
         mixin :message_shared
+      end
+
+      state :array_literal do
+        rule /]/, Punctuation, :pop!
+        rule /,/, Punctuation
+        mixin :statements
       end
 
       state :classname do


### PR DESCRIPTION
This pull request allow proper syntax coloring of constructs like 

``` ObjectiveC
NSArray *something = @[@"hello", @1, @[]];
```