### PR TITLE
Add support for lexing blocks as an argument to a method call and 

### DIFF
--- a/lib/rouge/demos/objective_c
+++ b/lib/rouge/demos/objective_c
@@ -10,3 +10,12 @@
 
 -(id)initWithAge:(int)age;
 @end
+
+@implementation Person
+-(void)doStuff {
+    [self executeBlock:^void(int x, NSString *y) {
+                          [self confirmPayment];
+                       }];
+}
+@end
+

--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -88,7 +88,6 @@ module Rouge
 
       state :message_shared do
         rule /\]/, Punctuation, :pop!
-        rule /;/, Error
 
         mixin :statement
       end


### PR DESCRIPTION
This allows lexing following snippets:

``` ObjectiveC
@implementation Person
-(void)doStuff {
    [self executeBlock:^void(int x, NSString *y) {
                          [self confirmPayment];
                       }];
}
@end
```

