### PR TITLE
Slim improvements

### DIFF
--- a/lib/rouge/lexers/slim.rb
+++ b/lib/rouge/lexers/slim.rb
@@ -158,7 +158,7 @@ module Rouge
 
       state :html_attr do
         # Strings, double/single quoted
-        rule %r(\s*(['"])#{dot}*\1), Literal::String, :pop!
+        rule(/\s*(['"])#{dot}*?\1/, Literal::String, :pop!)
 
         # Ruby stuff
         rule(/(#{ruby_chars}+\(.*?\))/) { |m| delegate ruby, m[1]; pop! }

--- a/lib/rouge/lexers/slim.rb
+++ b/lib/rouge/lexers/slim.rb
@@ -146,6 +146,9 @@ module Rouge
           delegate ruby, m[2]
         end
 
+        # HTML Entities
+        rule(/&\S*?;/, Name::Entity)
+
         rule /#{dot}+?/, Text
 
         rule /\s*\n/, Text::Whitespace, :pop!
@@ -195,6 +198,9 @@ module Rouge
         rule %r((</?[\w\s\=\'\"]+?/?>)) do |m| # Dirty html
           delegate html, m[1]
         end
+
+        # HTML Entities
+        rule(/&\S*?;/, Name::Entity)
 
         #rule /([^#\n]|#[^{\n]|(\\\\)*\\#\{)+/ do
         rule /#{dot}+?/, Text


### PR DESCRIPTION
* Fixes a bug with parsing strings (the regex was greedy, and would end at the last quotation mark instead of the first)
* Adds detection of HTML entities (e.g. `&amp;` `&copy;` etc.)