### PR TITLE
Add comment support to json lexer.

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -220,12 +220,8 @@ module Rouge
       state :root do
         mixin :whitespace
         mixin :comments
-        # special case for empty objects
-        rule /(\{)(\s*)(\})/m do
-          groups Punctuation, Text::Whitespace, Punctuation
-        end
         rule /(?:true|false|null)\b/, Keyword::Constant
-        rule /{/,  Punctuation, :object_key
+        rule /{/,  Punctuation, :object_key_initial
         rule /\[/, Punctuation, :array
         rule /-?(?:0|[1-9]\d*)\.\d+(?:e[+-]\d+)?/i, Num::Float
         rule /-?(?:0|[1-9]\d*)(?:e[+-]\d+)?/i, Num::Integer
@@ -244,6 +240,18 @@ module Rouge
         rule string, Str::Double
       end
 
+      # in object_key_initial it's allowed to immediately close the object again
+      state :object_key_initial do
+        mixin :whitespace
+        mixin :comments
+        rule string do
+          token Name::Tag
+          goto :object_key
+        end
+        rule /}/, Punctuation, :pop!
+      end
+
+      # in object_key at least one more name/value pair is required
       state :object_key do
         mixin :whitespace
         mixin :comments

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -219,6 +219,7 @@ module Rouge
 
       state :root do
         mixin :whitespace
+        mixin :comments
         # special case for empty objects
         rule /(\{)(\s*)(\})/m do
           groups Punctuation, Text::Whitespace, Punctuation
@@ -235,12 +236,17 @@ module Rouge
         rule /\s+/m, Text::Whitespace
       end
 
+      state :comments do
+        rule %r(//.*?$), Comment::Single
+      end
+
       state :has_string do
         rule string, Str::Double
       end
 
       state :object_key do
         mixin :whitespace
+        mixin :comments
         rule string, Name::Tag
         rule /:/, Punctuation, :object_val
         rule /}/, Error, :pop!


### PR DESCRIPTION
Allows to add comments in documentation of json formats. This commit only allows for one line comments, but should be easy to extend to /* ... */ style comments

This allows documentation in a style like this:
```
{
    "response": {
        "data": [
            // contact objects
        ],
        "limit": 10,
        "page": 1,
        "totalEntries": 15, // Note total entries changed
        "totalPages": 2
    }
}
```

Split into an basic commit to enable comments in all contexts except in otherwise empty objects and a separate commit to refactor handling of empty objects to be less of a special case and thus also support comments.