### PR TITLE
Add comment and ellipsis support to json lexer.

### DIFF
--- a/lib/rouge/demos/json-doc
+++ b/lib/rouge/demos/json-doc
@@ -1,0 +1,1 @@
+{ "one": 1, "two": 2, "null": null, "simple": true } // a simple json object

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -272,14 +272,20 @@ module Rouge
 
       prepend :root do
         mixin :comments
+        rule /(\.\.\.)/, Comment::Single
       end
 
       prepend :object_key_initial do
         mixin :comments
+        rule /(\.\.\.)/, Comment::Single
       end
 
       prepend :object_key do
         mixin :comments
+        rule /(\.\.\.)/ do
+          token Comment::Single
+          goto :object_key_initial
+        end
       end
 
       state :comments do

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -265,5 +265,27 @@ module Rouge
         mixin :root
       end
     end
+
+    class JSONDOC < JSON
+      desc "JavaScript Object Notation with extenstions for documentation"
+      tag 'json-doc'
+
+      prepend :root do
+        mixin :comments
+      end
+
+      prepend :object_key_initial do
+        mixin :comments
+      end
+
+      prepend :object_key do
+        mixin :comments
+      end
+
+      state :comments do
+        rule %r(//.*?$), Comment::Single
+      end
+    end
+
   end
 end

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -219,12 +219,8 @@ module Rouge
 
       state :root do
         mixin :whitespace
-        # special case for empty objects
-        rule /(\{)(\s*)(\})/m do
-          groups Punctuation, Text::Whitespace, Punctuation
-        end
         rule /(?:true|false|null)\b/, Keyword::Constant
-        rule /{/,  Punctuation, :object_key
+        rule /{/,  Punctuation, :object_key_initial
         rule /\[/, Punctuation, :array
         rule /-?(?:0|[1-9]\d*)\.\d+(?:e[+-]\d+)?/i, Num::Float
         rule /-?(?:0|[1-9]\d*)(?:e[+-]\d+)?/i, Num::Integer
@@ -239,6 +235,17 @@ module Rouge
         rule string, Str::Double
       end
 
+      # in object_key_initial it's allowed to immediately close the object again
+      state :object_key_initial do
+        mixin :whitespace
+        rule string do
+          token Name::Tag
+          goto :object_key
+        end
+        rule /}/, Punctuation, :pop!
+      end
+
+      # in object_key at least one more name/value pair is required
       state :object_key do
         mixin :whitespace
         rule string, Name::Tag

--- a/spec/visual/samples/json-doc
+++ b/spec/visual/samples/json-doc
@@ -9,6 +9,20 @@
         "postalCode": "10021",
         "country": "US"
     },
+    "ellipsis": {
+        "object": { ... },
+        ...
+        "list": [ ... ],
+        "locations": {
+            ...
+            "city": "New York",
+            ...
+            "postalCode": "10021",
+            ...
+        },
+        "key": ...,
+        ...
+    },
     "comments": { // comments
         "key": "value", // in
         "list": [
@@ -18,6 +32,7 @@
         "emptyObject": { // comment
         }
     },
+    ...
     "errors": {
         "object": { "a", "b" }
     },

--- a/spec/visual/samples/json-doc
+++ b/spec/visual/samples/json-doc
@@ -1,0 +1,25 @@
+{
+    "firstName": "John",
+    "lastName": "Smith",
+    "age": 25,
+    "address": {
+        "streetAddress": "21 2nd Street",
+        "city": "New York",
+        "state": "NY",
+        "postalCode": "10021",
+        "country": "US"
+    },
+    "comments": { // comments
+        "key": "value", // in
+        "list": [
+            // most
+        ], // locations
+        "key": "value",
+        "emptyObject": { // comment
+        }
+    },
+    "errors": {
+        "object": { "a", "b" }
+    },
+    "emptyObject": {} // comment
+}


### PR DESCRIPTION
This pull request adds ellipsis support in addition to comment support from [pull request 243](https://github.com/jneen/rouge/pull/243).

Omitting key/value pairs with the comment syntax (i.e. // ... ) is awkward because if used at the end of an object you need to change the preceeding line to remove a trailing comma. This PR adds an syntax that looks better and also removes the special case when used at the end of an object.

Example:
```
    {
        "accountId": "someone@example.com",
        "id": "15",
        "addDate": "2015-01-01T00:00:00",
        "lastChangeDate": "2015-01-01T00:00:00",
        ...
    }
```