### PR TITLE
Swift 1.2 changes

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -113,6 +113,8 @@ module Rouge
             token Name::Function
           end
         end
+        
+        rule /as[?!]?/, Keyword
 
         rule /(#?(?!default)(?![[:upper:]])#{id})(\s*)(:)/ do
           groups Name::Variable, Text, Punctuation

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -26,7 +26,7 @@ module Rouge
       )
 
       attributes = Set.new %w(
-        autoclosure IBAction IBDesignable IBInspectable IBOutlet noreturn NSCopying NSManaged objc UIApplicationMain NSApplicationMain objc_block
+        autoclosure IBAction IBDesignable IBInspectable IBOutlet noreturn NSCopying NSManaged objc UIApplicationMain NSApplicationMain objc_block noescape
       )
 
       constants = Set.new %w(
@@ -75,6 +75,8 @@ module Rouge
         rule /(@objc[(])([^)]+)([)])/ do
           groups Keyword::Declaration, Name::Class, Keyword::Declaration
         end
+        
+        rule /@autoclosure\(escaping\)/, Keyword::Declaration
 
         rule /@(#{id})/ do |m|
           if attributes.include? m[1]

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -163,10 +163,20 @@ let incrementor = makeIncrementor(firstNumber: 4)
 incrementor()
 
 // @autoclosure
-func simpleAssert(condition: @autoclosure () -> Bool, message: String = "Assertion failed") {
+func simpleAssert(@autoclosure condition: () -> Bool, message: String = "Assertion failed") {
     if !condition() {
         println(message)
     }
+}
+
+func lazyAssertion(@autoclosure(escaping) condition: () -> Bool, message: String = "") {
+    lazyAssertions.append(condition)
+}
+
+func autoreleasepool(@noescape code: () -> ()) {
+    pushAutoreleasePool()
+    code()
+    popAutoreleasePool()
 }
 
 // optional function call

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -13,6 +13,10 @@ sayHello("Toto")
 
 var pi = 3.1415
 
+var foo = cast as SomeType
+var foo = optionalCast as? SomeType
+var foo = forcedCast as! SomeType
+
 func halfOpenRangeLength(start:Int, end:Int) -> Int {
     return end - start
 }


### PR DESCRIPTION
- `@noescape` and `@autoclosure(escaping)` attributes are recognized
- renders `as?` and `as!` operators as a single keyword (instead of `as` being a keyword then a random character which looks weird)