### PR TITLE
Support for `application/hal+json` mimetype

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -206,7 +206,7 @@ module Rouge
       desc "JavaScript Object Notation (json.org)"
       tag 'json'
       filenames '*.json'
-      mimetypes 'application/json'
+      mimetypes 'application/json', 'application/hal+json'
 
       # TODO: is this too much of a performance hit?  JSON is quite simple,
       # so I'd think this wouldn't be too bad, but for large documents this


### PR DESCRIPTION
Hal (Hypertext application language) is a specification for a consistent and easy way to hyperlink between resources, as specified here http://stateless.co/hal_specification.html.

This PR just define another mimetype for JSON to handle `application/hal+json` responses.