### PR TITLE
Improve diff lexer

### DIFF
--- a/lib/rouge/lexers/diff.rb
+++ b/lib/rouge/lexers/diff.rb
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*- #
-
 module Rouge
   module Lexers
     class Diff < RegexLexer
-      title "diff"
-      desc "Lexes unified diffs or patches"
+      title 'diff'
+      desc 'Lexes unified diffs or patches'
 
       tag 'diff'
       aliases 'patch', 'udiff'
@@ -15,26 +13,21 @@ module Rouge
         return 1   if text.start_with?('Index: ')
         return 1   if text.start_with?('diff ')
 
+        # TODO: Have a look at pygments here, seems better
         return 0.9 if text =~ /\A---.*?\n\+\+\+/m
       end
 
-      state :header do
-        rule /^diff .*?\n(?=---|\+\+\+)/m, Generic::Heading
-        rule /^--- .*?\n/, Generic::Deleted
-        rule /^\+\+\+ .*?\n/, Generic::Inserted
-      end
-
-      state :diff do
-        rule /@@ -\d+,\d+ \+\d+,\d+ @@.*?\n/, Generic::Heading
-        rule /^\+.*?\n/, Generic::Inserted
-        rule /^-.*?\n/,  Generic::Deleted
-        rule /^ .*?\n/,  Text
-        rule /^.*?\n/,   Error
-      end
-
       state :root do
-        mixin :header
-        mixin :diff
+        rule(/^ .*\n/, Text)
+        rule(/^\+.*\n/, Generic::Inserted)
+        # Do not highlight the delimiter line
+        # before the diffstat in email patches.
+        rule(/^-+ .*\n/, Generic::Deleted)
+        rule(/^!.*\n/, Generic::Strong)
+        rule(/^@.*\n/, Generic::Subheading)
+        rule(/^([Ii]ndex|diff).*\n/, Generic::Heading)
+        rule(/^=.*\n/, Generic::Heading)
+        rule(/.*\n/, Text)
       end
     end
   end


### PR DESCRIPTION
As I promised, here is the first one. I currently have a little time problem, but anyway, I will try to continuously submit my thoughts/improvements.

From the commit message:

The diff lexer was a bit buggy. It also did not work correctly
with email patches. This commit ensures correct patch highlighting.

Furthermore I removed the error token which caused problems on gitlab.
As a diff is rather trivial I think it is safe to remove it.

see: https://github.com/rumpelsepp/rugments/issues/10