### PR TITLE
Register JSON API mimetype for JSON lexer

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -206,7 +206,7 @@ module Rouge
       desc "JavaScript Object Notation (json.org)"
       tag 'json'
       filenames '*.json'
-      mimetypes 'application/json'
+      mimetypes 'application/json', 'application/vnd.api+json'
 
       # TODO: is this too much of a performance hit?  JSON is quite simple,
       # so I'd think this wouldn't be too bad, but for large documents this

--- a/spec/lexers/javascript_spec.rb
+++ b/spec/lexers/javascript_spec.rb
@@ -23,6 +23,7 @@ describe Rouge::Lexers::Javascript do
     it 'guesses by mimetype' do
       assert_guess :mimetype => 'text/javascript'
       assert_guess Rouge::Lexers::JSON, :mimetype => 'application/json'
+      assert_guess Rouge::Lexers::JSON, :mimetype => 'application/vnd.api+json'
     end
 
     it 'guesses by source' do


### PR DESCRIPTION
[JSON API](http://jsonapi.org/) is a standard for building APIs in JSON. It is registered with the
IANA as application/vnd.api+json -
http://www.iana.org/assignments/media-types/application/vnd.api+json

This adds support for highlighting JSON API media types as JSON.