### PR TITLE
Add a lexer for API Blueprint

### DIFF
--- a/lib/rouge/demos/apiblueprint
+++ b/lib/rouge/demos/apiblueprint
@@ -1,0 +1,33 @@
+FORMAT: 1A
+HOST: http://polls.apiblueprint.org/
+
+# Polls
+
+Polls is a simple API allowing consumers to view polls and vote in them.
+
+# Polls API Root [/]
+
+## Group Question
+
+Resources related to questions in the API.
+
+## Question [/questions/{question_id}]
+
++ Parameters
+    + question_id: 1 (number, required) - ID of the Question in form of an integer
+
++ Attributes
+    + question: `Favourite programming language?` (required)
+    + published_at: `2014-11-11T08:40:51.620Z` - An ISO8601 date when the question was published
+    + choices (array[Choice], required) - An array of Choice objects
+    + url: /questions/1
+
+### View a Questions Detail [GET]
+
++ Response 200 (application/json)
+    + Attributes (Question)
+
+### Delete a Question [DELETE]
+
++ Relation: delete
++ Response 204

--- a/lib/rouge/lexers/apiblueprint.rb
+++ b/lib/rouge/lexers/apiblueprint.rb
@@ -1,0 +1,51 @@
+module Rouge
+  module Lexers
+    load_lexer 'markdown.rb'
+
+    class APIBlueprint < Markdown
+      title 'API Blueprint'
+      desc 'Markdown based API description language.'
+
+      tag 'apiblueprint'
+      aliases 'apiblueprint', 'apib'
+      filenames '*.apib'
+      mimetypes 'text/vnd.apiblueprint'
+
+      def self.analyze_text(text)
+        return 1 if text.start_with?('FORMAT: 1A\n')
+      end
+
+      prepend :root do
+        # Metadata
+        rule(/(\S+)(:\s*)(.*)$/) do
+          groups Name::Variable, Punctuation, Literal::String
+        end
+
+        # Resource Group
+        rule(/^(#+)(\s*Group\s+)(.*)$/) do
+          groups Punctuation, Keyword, Generic::Heading
+        end
+
+        # Resource \ Action
+        rule(/^(#+)(.*)(\[.*\])$/) do
+          groups Punctuation, Generic::Heading, Literal::String
+        end
+
+        # Relation
+        rule(/^([\+\-\*])(\s*Relation:)(\s*.*)$/) do
+          groups Punctuation, Keyword, Literal::String
+        end
+
+        # MSON
+        rule(/^(\s+[\+\-\*]\s*)(Attributes|Parameters)(.*)$/) do
+          groups Punctuation, Keyword, Literal::String
+        end
+
+        # Request/Response
+        rule(/^([\+\-\*]\s*)(Request|Response)(\s+\d\d\d)?(.*)$/) do
+          groups Punctuation, Keyword, Literal::Number, Literal::String
+        end
+      end
+    end
+  end
+end

--- a/spec/lexers/apiblueprint_spec.rb
+++ b/spec/lexers/apiblueprint_spec.rb
@@ -1,0 +1,15 @@
+describe Rouge::Lexers::APIBlueprint do
+  let(:subject) { Rouge::Lexers::APIBlueprint.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.apib'
+    end
+
+    it 'guesses by source' do
+      assert_guess :source => 'FORMAT: 1A\n\n# My API\n'
+    end
+  end
+end

--- a/spec/visual/samples/apiblueprint
+++ b/spec/visual/samples/apiblueprint
@@ -1,0 +1,33 @@
+FORMAT: 1A
+HOST: http://polls.apiblueprint.org/
+
+# Polls
+
+Polls is a simple API allowing consumers to view polls and vote in them.
+
+# Polls API Root [/]
+
+## Group Question
+
+Resources related to questions in the API.
+
+## Question [/questions/{question_id}]
+
++ Parameters
+    + question_id: 1 (number, required) - ID of the Question in form of an integer
+
++ Attributes
+    + question: `Favourite programming language?` (required)
+    + published_at: `2014-11-11T08:40:51.620Z` - An ISO8601 date when the question was published
+    + choices (array[Choice], required) - An array of Choice objects
+    + url: /questions/1
+
+### View a Questions Detail [GET]
+
++ Response 200 (application/json)
+    + Attributes (Question)
+
+### Delete a Question [DELETE]
+
++ Relation: delete
++ Response 204


### PR DESCRIPTION
This pull request adds a lexer for [API Blueprint](https://apiblueprint.org), a simple Markdown based web API description language.