### PR TITLE
Fix bugs in liquid lexer (closes #237)

### DIFF
--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -131,9 +131,7 @@ module Rouge
           groups nil, Operator, Operator::Word
         end
 
-        rule /([\w\.\'"]+)(\s+)(contains)(\s+)([\w\.\'"]+)/ do
-          groups nil, Text::Whitespace, Operator::Word, Text::Whitespace
-        end
+        rule /(contains)/, Operator::Word
 
         mixin :generic
         mixin :whitespace
@@ -168,6 +166,7 @@ module Rouge
       # states for unknown markup
       state :param_markup do
         mixin :whitespace
+        mixin :string
 
         rule /([^\s=:]+)(\s*)(=|:)/ do
           groups Name::Attribute, Text::Whitespace, Operator
@@ -177,7 +176,6 @@ module Rouge
           groups Punctuation, Text::Whitespace, nil, Text::Whitespace, Punctuation
         end
 
-        mixin :string
         mixin :number
         mixin :keyword
 
@@ -196,12 +194,12 @@ module Rouge
       end
 
       state :tag_markup do
-        rule (/%\}/) { token Punctuation; reset_stack }
+        mixin :end_of_block
         mixin :default_param_markup
       end
 
       state :variable_tag_markup do
-        rule (/%\}/) { token Punctuation; reset_stack }
+        mixin :end_of_block
         mixin :variable_param_markup
       end
 
@@ -225,7 +223,13 @@ module Rouge
         rule /\d+/, Num::Integer
       end
 
+      state :array_index do
+        rule /\[/, Punctuation
+        rule /\]/, Punctuation
+      end
+
       state :generic do
+        mixin :array_index
         mixin :keyword
         mixin :string
         mixin :variable
@@ -258,6 +262,7 @@ module Rouge
 
       state :assign do
         mixin :whitespace
+        mixin :end_of_block
 
         rule /(\s*)(=)(\s*)/ do
           groups Text::Whitespace, Operator, Text::Whitespace

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -58,14 +58,15 @@ Some other {{ output }}!
 {% include file.html param = 'value' param2 = object %}
 {% include 'snippet' param = 'value' param2 = object %}
 
-{% assign page_has_image = false %}  
-{% assign img_tag = '<' | append: 'img' %}  
+{% assign page_has_image = false %}
+{% assign img_tag = '<' | append: 'img' %}
 {% if link.object.content contains img_tag %}
   {% assign src = link.object.content | split: 'src="' %}
   {% assign src = src[1] | split: '"' | first %}
     {% if src %}
       {% assign page_has_image = true %}
-      {% assign image_src = src | replace: '_small', '' | replace: '_compact', '' | replace: '_medium', '' | replace: '_large', '' | replace: '_grande', '' %}
+      {% assign image_src = src | replace: '_small', '' | replace: '_compact', '' | replace: '_medium', '' |
+                                  replace: '_large', '' | replace: '_grande', '' %}
     {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Finally had some time to fix those couple of bugs with the liquid lexer. Thanks to @bekreatief for the added sample code.

* Fixes a bug with the `contains` operator in if blocks, where both sides of the of the operation would not be displayed correctly.
* Fixes a bug with filter arguments where single and double quotes could not be nested.
* Fixes a bug where array indices (using square bracket notation) would not be parsed.