### PR TITLE
Pass lexer options to enumeration to support continue use case

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -376,7 +376,7 @@ module Rouge
     # @option opts :continue
     #   Continue the lex from the previous state (i.e. don't call #reset!)
     def lex(string, opts={}, &b)
-      return enum_for(:lex, string) unless block_given?
+      return enum_for(:lex, string, opts) unless block_given?
 
       Lexer.assert_utf8!(string)
 


### PR DESCRIPTION
There is no way to use the `continue` option in `lexer.lex` if the enumeration mode is used. This will be needed to support proper syntax highlighting when blocks of code are streamed and formatted.