### PR TITLE
Abandon ruby 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - "1.9.3"
   - "2.0"
   - "2.1"
   # - jruby-19mode # JRuby in 1.9 mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - "2.0"
   - "2.1"
+  - "2.2"
   # - jruby-19mode # JRuby in 1.9 mode
   # - rbx-2.1.1
 bundler_args: --without development


### PR DESCRIPTION
Ruby 1.9 is dead!
Ruby 2.2 is out there, so let's adjust travis ci!