### PR TITLE
Disable not existing rules in C# lexer

### DIFF
--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -44,9 +44,9 @@ module Rouge
         mixin :whitespace
 
         rule /^\s*\[.*?\]/, Name::Attribute
-        rule /[$]\s*"/, Str, :splice_string
-        rule /[$]\s*<#/, Str, :splice_recstring
-        rule /<#/, Str, :recstring
+        # rule /[$]\s*"/, Str, :splice_string
+        # rule /[$]\s*<#/, Str, :splice_recstring
+        # rule /<#/, Str, :recstring
 
         rule /(<\[)\s*(#{id}:)?/, Keyword
         rule /\]>/, Keyword


### PR DESCRIPTION
This patch disables some rules in the c# lexer which does not exist.

Reported by Douwe Maan: https://github.com/rumpelsepp/rugments/issues/12