### PR TITLE
Fixing prolog lexer issue on camelCase atoms

### DIFF
--- a/lib/rouge/lexers/prolog.rb
+++ b/lib/rouge/lexers/prolog.rb
@@ -30,7 +30,7 @@ module Rouge
       end
 
       state :atoms do
-        rule /[[:lower:]]([_[:lower:][:digit:]])*/, Str::Symbol
+        rule /[[:lower:]]([_[:word:][:digit:]])*/, Str::Symbol
         rule /'[^']*'/, Str::Symbol
       end
 

--- a/spec/visual/samples/prolog
+++ b/spec/visual/samples/prolog
@@ -4,6 +4,7 @@ x
 blue
 'Burrito'
 'some atom'
+camelCaseAtom
 
 # Numbers
 


### PR DESCRIPTION
Although camelCase atoms - as well as functor's and predicate's names -
are sometimes considered a bad practice, they are actually valid.

Before this commit, a camelCaseAtom would be highlighted as **camel**CaseAtom.
Now, it is properly highlighted as **camelCaseAtom**