### PR TITLE
Fix C lexer w.r.t function declarations

### DIFF
--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -158,10 +158,10 @@ module Rouge
         )mx do |m|
           # TODO: do this better.
           recurse m[1]
-          token Name::Function
+          token Name::Function, m[2]
           recurse m[3]
           recurse m[4]
-          token Punctuation
+          token Punctuation, m[5]
           push :statement
         end
 

--- a/spec/visual/samples/c
+++ b/spec/visual/samples/c
@@ -32,6 +32,20 @@ static int not_a_comment();
 #macro
 
 
+/* Bug #277: C function prototype syntax highlighting broken if space before semicolon */
+
+void foo() ;
+
+void foo() {
+    /* nothing */
+}
+
+void foo2(void)
+{
+    /* nothing */
+}
+
+
 /* Execute compiled code */
 
 /* XXX TO DO:


### PR DESCRIPTION
These tokens were missing the specific regex match arguments, causing
duplicated output.

This fixes #277.