### PR TITLE
Recognize ".vb" files as Visual Basic code

### DIFF
--- a/lib/rouge/lexers/vb.rb
+++ b/lib/rouge/lexers/vb.rb
@@ -7,7 +7,7 @@ module Rouge
       desc "Visual Basic"
       tag 'vb'
       aliases 'visualbasic'
-      filenames '*.vbs'
+      filenames '*.vbs', '*.vb'
       mimetypes 'text/x-visualbasic', 'application/x-visualbasic'
 
       def self.keywords


### PR DESCRIPTION
Since ".vb" is the default extension of Visual Basic files on Visual Studio, it should be recognized as Visual Basic code's.
Please consider.