### PR TITLE
Add support to javascript interpolation (ES6) syntax

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -161,6 +161,7 @@ module Rouge
         rule /[0-9]+/, Num::Integer
         rule /"(\\\\|\\"|[^"])*"/, Str::Double
         rule /'(\\\\|\\'|[^'])*'/, Str::Single
+        rule /`(\\\\|\\`|[^`])*`/, Str::Backtick
       end
 
       # braced parts that aren't object literals

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -173,7 +173,7 @@ module Rouge
       end
 
       state :interpolation do
-        rule /[}]/, Str::Interpol, :pop!
+        rule /(})(?!.+})/, Str::Interpol, :pop!
         mixin :root
       end
 

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -161,7 +161,20 @@ module Rouge
         rule /[0-9]+/, Num::Integer
         rule /"(\\\\|\\"|[^"])*"/, Str::Double
         rule /'(\\\\|\\'|[^'])*'/, Str::Single
-        rule /`(\\\\|\\`|[^`])*`/, Str::Backtick
+        rule /`/, Str::Backtick, :backtick_string
+
+      end
+
+      state :backtick_string do
+        rule /`/, Str::Backtick, :pop!
+        rule /[$][{]/, Str::Interpol, :interpolation
+        rule /\$[^{]/, Str::Backtick
+        rule /[^`$]+/, Str::Backtick
+      end
+
+      state :interpolation do
+        rule /[}]/, Str::Interpol, :pop!
+        mixin :root
       end
 
       # braced parts that aren't object literals

--- a/spec/lexers/javascript_spec.rb
+++ b/spec/lexers/javascript_spec.rb
@@ -28,7 +28,7 @@ describe Rouge::Lexers::Javascript do
                           ['Literal.String.Backtick', "`"]
     end
 
-    it 'lexes multiline strings' do
+    it 'lexes multiline interpolated expressions' do
       assert_tokens_equal %(`Value: \n${10+20}\n`),
                           ['Literal.String.Backtick', "`Value: \n"],
                           ['Literal.String.Interpol', '${'],

--- a/spec/lexers/javascript_spec.rb
+++ b/spec/lexers/javascript_spec.rb
@@ -17,6 +17,15 @@ describe Rouge::Lexers::Javascript do
 
     end
 
+    it 'lexes interpolated variables' do
+      assert_tokens_equal %(`Value ${variable}`),
+                          ['Literal.String.Backtick', '`Value '],
+                          ['Literal.String.Interpol', '${'],
+                          ['Name.Other', 'variable'],
+                          ['Literal.String.Interpol', '}'],
+                          ['Literal.String.Backtick', '`']
+    end
+
     it 'lexes interpolated expressions' do
       assert_tokens_equal %(`Value: ${10+20}`),
                           ['Literal.String.Backtick', "`Value: "],
@@ -37,6 +46,22 @@ describe Rouge::Lexers::Javascript do
                           ['Literal.Number.Integer', '20'],
                           ['Literal.String.Interpol', '}'],
                           ['Literal.String.Backtick', "\n`"]
+    end
+
+    it 'does not consider $variable as interpolation' do
+      assert_tokens_equal %(`Value: $variable`),
+                          ['Literal.String.Backtick', '`Value: $variable`']
+    end
+
+    it 'does not interpolate single quoted strings' do
+      assert_tokens_equal %('Value: ${variable}'),
+                          ['Literal.String.Single', "'Value: ${variable}'"]
+    end
+
+    it 'does not interpolate double quoted strings' do
+      assert_tokens_equal %("Value: ${variable}"),
+                          ['Literal.String.Double', %("Value: ${variable}")]
+
     end
 
   end

--- a/spec/lexers/javascript_spec.rb
+++ b/spec/lexers/javascript_spec.rb
@@ -48,6 +48,22 @@ describe Rouge::Lexers::Javascript do
                           ['Literal.String.Backtick', "\n`"]
     end
 
+    it 'lexes interpolated expressions containing objects' do
+      assert_tokens_equal %(`foo ${{bar: 'baz'}.bar} qux`),
+                         ["Literal.String.Backtick", "`foo "],
+                         ["Literal.String.Interpol", "${"],
+                         ["Punctuation", "{"],
+                         ["Name.Label", "bar"],
+                         ["Punctuation", ":"],
+                         ["Text", " "],
+                         ["Literal.String.Single", "'baz'"],
+                         ["Punctuation", "}."],
+                         ["Name.Other", "bar"],
+                         ["Literal.String.Interpol", "}"],
+                         ["Literal.String.Backtick", " qux`"]
+
+    end
+
     it 'does not consider $variable as interpolation' do
       assert_tokens_equal %(`Value: $variable`),
                           ['Literal.String.Backtick', '`Value: $variable`']

--- a/spec/lexers/javascript_spec.rb
+++ b/spec/lexers/javascript_spec.rb
@@ -10,6 +10,35 @@ describe Rouge::Lexers::Javascript do
       assert_has_token 'Error',          "var a = /foo;\n1"
       assert_has_token 'Literal.Number', "var a = /foo;\n1"
     end
+
+    it 'lexes strings with backticks' do
+      assert_tokens_equal %(`Value`),
+                          ['Literal.String.Backtick', "`Value`"]
+
+    end
+
+    it 'lexes interpolated expressions' do
+      assert_tokens_equal %(`Value: ${10+20}`),
+                          ['Literal.String.Backtick', "`Value: "],
+                          ['Literal.String.Interpol', '${'],
+                          ['Literal.Number.Integer', '10'],
+                          ['Operator', '+'],
+                          ['Literal.Number.Integer', '20'],
+                          ['Literal.String.Interpol', '}'],
+                          ['Literal.String.Backtick', "`"]
+    end
+
+    it 'lexes multiline strings' do
+      assert_tokens_equal %(`Value: \n${10+20}\n`),
+                          ['Literal.String.Backtick', "`Value: \n"],
+                          ['Literal.String.Interpol', '${'],
+                          ['Literal.Number.Integer', '10'],
+                          ['Operator', '+'],
+                          ['Literal.Number.Integer', '20'],
+                          ['Literal.String.Interpol', '}'],
+                          ['Literal.String.Backtick', "\n`"]
+    end
+
   end
 
   describe 'guessing' do

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -52,6 +52,7 @@ var variableInterpolation = `Welcome ${name}`
 var expressionInterpolation = `The area of a circle with radius 5 is ${Math.PI * 5 * 5}`
 var multilineInterpolation = `Welcome ${name}
                               Today is ${new Date()}`
+var interpolationContainingObject = `foo ${{bar: 'baz'}.bar} qux`
 
 Blag = {};
 jQuery.noConflict();

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -47,6 +47,12 @@ var quotedKeys = {
   "three": 3,
 };
 
+// interpolation
+var variableInterpolation = `Welcome ${name}`
+var expressionInterpolation = `The area of a circle with radius 5 is ${Math.PI * 5 * 5}`
+var multilineInterpolation = `Welcome ${name}
+                              Today is ${new Date()}`
+
 Blag = {};
 jQuery.noConflict();
 


### PR DESCRIPTION
This PR adds support to the new ES6 interpolation (backtick) syntax.

In other words, it detects strings created using backticks in JavaScript (see example below):

```js
var username = 'jneen';
var url = `https://api.github.com/users/${username}`;
```

You can read more about the new interpolation syntax here: [http://es6-features.org/#CustomInterpolation](http://es6-features.org/#CustomInterpolation)

Before this change, running rouge against a JS code snippet was incorrectly yielding this result:

![before](https://cloud.githubusercontent.com/assets/2975955/8714145/fe6487a2-2b47-11e5-9014-c767767a491f.png)

After:
![after](https://cloud.githubusercontent.com/assets/2975955/8714133/dc8b0854-2b47-11e5-9907-7c3f5919669a.png)

Fix #289