### PR TITLE
Use require instead of load to handle double loading

### DIFF
--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -29,29 +29,29 @@ module Rouge
 end
 
 load_dir = Pathname.new(__FILE__).dirname
-load load_dir.join('rouge/version.rb')
+require load_dir.join('rouge/version.rb')
 
-load load_dir.join('rouge/util.rb')
+require load_dir.join('rouge/util.rb')
 
-load load_dir.join('rouge/text_analyzer.rb')
-load load_dir.join('rouge/token.rb')
+require load_dir.join('rouge/text_analyzer.rb')
+require load_dir.join('rouge/token.rb')
 
-load load_dir.join('rouge/lexer.rb')
-load load_dir.join('rouge/regex_lexer.rb')
-load load_dir.join('rouge/template_lexer.rb')
+require load_dir.join('rouge/lexer.rb')
+require load_dir.join('rouge/regex_lexer.rb')
+require load_dir.join('rouge/template_lexer.rb')
 
-Dir.glob(load_dir.join('rouge/lexers/*.rb')).each { |f| load f }
+Dir.glob(load_dir.join('rouge/lexers/*.rb')).each { |f| require f }
 
-load load_dir.join('rouge/formatter.rb')
-load load_dir.join('rouge/formatters/html.rb')
-load load_dir.join('rouge/formatters/terminal256.rb')
-load load_dir.join('rouge/formatters/null.rb')
+require load_dir.join('rouge/formatter.rb')
+require load_dir.join('rouge/formatters/html.rb')
+require load_dir.join('rouge/formatters/terminal256.rb')
+require load_dir.join('rouge/formatters/null.rb')
 
-load load_dir.join('rouge/theme.rb')
-load load_dir.join('rouge/themes/thankful_eyes.rb')
-load load_dir.join('rouge/themes/colorful.rb')
-load load_dir.join('rouge/themes/base16.rb')
-load load_dir.join('rouge/themes/github.rb')
-load load_dir.join('rouge/themes/monokai.rb')
-load load_dir.join('rouge/themes/molokai.rb')
-load load_dir.join('rouge/themes/monokai_sublime.rb')
+require load_dir.join('rouge/theme.rb')
+require load_dir.join('rouge/themes/thankful_eyes.rb')
+require load_dir.join('rouge/themes/colorful.rb')
+require load_dir.join('rouge/themes/base16.rb')
+require load_dir.join('rouge/themes/github.rb')
+require load_dir.join('rouge/themes/monokai.rb')
+require load_dir.join('rouge/themes/molokai.rb')
+require load_dir.join('rouge/themes/monokai_sublime.rb')

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -437,7 +437,7 @@ module Rouge
       return if const_defined?(const_name)
 
       root = Pathname.new(__FILE__).dirname.join('lexers')
-      load root.join(relpath)
+      require root.join(relpath)
     end
   end
 end

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -18,7 +18,7 @@ module Rouge
 
       # self-modifying method that loads the keywords file
       def self.keywords
-        load Pathname.new(__FILE__).dirname.join('gherkin/keywords.rb')
+        require Pathname.new(__FILE__).dirname.join('gherkin/keywords.rb')
         keywords
       end
 

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -21,7 +21,7 @@ module Rouge
       end
 
       def self.builtins
-        load Pathname.new(__FILE__).dirname.join('lua/builtins.rb')
+        require Pathname.new(__FILE__).dirname.join('lua/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/matlab.rb
+++ b/lib/rouge/lexers/matlab.rb
@@ -22,7 +22,7 @@ module Rouge
       end
 
       def self.builtins
-        load Pathname.new(__FILE__).dirname.join('matlab/builtins.rb')
+        require Pathname.new(__FILE__).dirname.join('matlab/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -26,7 +26,7 @@ module Rouge
       end
 
       def self.builtins
-        load Pathname.new(__FILE__).dirname.join('php/builtins.rb')
+        require Pathname.new(__FILE__).dirname.join('php/builtins.rb')
         self.builtins
       end
 

--- a/lib/rouge/lexers/viml.rb
+++ b/lib/rouge/lexers/viml.rb
@@ -13,7 +13,7 @@ module Rouge
       mimetypes 'text/x-vim'
 
       def self.keywords
-        load Pathname.new(__FILE__).dirname.join('viml/keywords.rb')
+        require Pathname.new(__FILE__).dirname.join('viml/keywords.rb')
         self.keywords
       end
 


### PR DESCRIPTION
Closes #290.

The bug was caused by Powershell being loaded before Shell, which is exactly what `$LOADED_FEATURES` was designed to solve.