### PR TITLE
Working towards #287

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -50,18 +50,9 @@ module Rouge
       id = /[a-z_]\w*/i
       hex = /[0-9a-f]/i
       escapes = %r(
-        \\ ([nrt'\\] | x#{hex}{2} | u#{hex}{4} | U#{hex}{8})
+        \\ ([nrt"'\\] | x#{hex}{2} | u#{hex}{4} | U#{hex}{8})
       )x
       size = /8|16|32|64/
-
-      state :start_line do
-        mixin :whitespace
-        rule /\s+/, Text
-        rule /#\[/ do
-          token Comment::Preproc; push :attribute
-        end
-        rule(//) { pop! }
-      end
 
       state :attribute do
         mixin :whitespace
@@ -78,15 +69,19 @@ module Rouge
       end
 
       state :root do
-        rule /\n/, Text, :start_line
+        rule /\n/, Text
         mixin :whitespace
         rule /\b(?:#{Rust.keywords.join('|')})\b/, Keyword
         mixin :has_literals
+        
+        rule /#!*\[/ do
+          token Comment::Preproc; push :attribute
+        end
 
         rule %r([=-]>), Keyword
         rule %r(<->), Keyword
         rule /[()\[\]{}|,:;]/, Punctuation
-        rule /[*!@~&+%^<>=-]/, Operator
+        rule /[*!@~\/&+%^<>=-]/, Operator
 
         rule /([.]\s*)?#{id}(?=\s*[(])/m, Name::Function
         rule /[.]\s*#{id}/, Name::Property

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -1,3 +1,22 @@
+#![feature(box_syntax, box_patterns)]
+
+fn calculator() {
+    let program = "+ + * - /";
+    let mut accumulator = 0;
+
+    for token in program.chars() {
+        match token {
+            '+' => accumulator += 1,
+            '-' => accumulator -= 1,
+            '*' => accumulator *= 2,
+            '/' => accumulator /= 2,
+            _   => {}
+        }
+    }
+
+    println!("The program \"{}\" calculates the value {}", program, accumulator);
+}
+
 fn f() {
     let a = ~"hello";
     let b: &str = a;


### PR DESCRIPTION
Fixed:

- `start_line` highlighting preprocessor commands as errors (`#!`)
- String escape highlighted as an error
- Attribute interiors highlighted as function, but all other Rust highlighters I've seen style the entire line like the preprocessor token in C
- Attributes not on the very first line were highlighted differently from attributes on the first line