### PR TITLE
Fix diff lexer highlighting of deleted lines.

### DIFF
--- a/lib/rouge/lexers/diff.rb
+++ b/lib/rouge/lexers/diff.rb
@@ -12,17 +12,13 @@ module Rouge
       def self.analyze_text(text)
         return 1   if text.start_with?('Index: ')
         return 1   if text.start_with?('diff ')
-
-        # TODO: Have a look at pygments here, seems better
-        return 0.9 if text =~ /\A---.*?\n\+\+\+/m
+        return 0.9 if text.start_with?('--- ')
       end
 
       state :root do
         rule(/^ .*\n/, Text)
         rule(/^\+.*\n/, Generic::Inserted)
-        # Do not highlight the delimiter line
-        # before the diffstat in email patches.
-        rule(/^-+ .*\n/, Generic::Deleted)
+        rule(/^-+.*\n/, Generic::Deleted)
         rule(/^!.*\n/, Generic::Strong)
         rule(/^@.*\n/, Generic::Subheading)
         rule(/^([Ii]ndex|diff).*\n/, Generic::Heading)

--- a/lib/rouge/lexers/diff.rb
+++ b/lib/rouge/lexers/diff.rb
@@ -17,6 +17,7 @@ module Rouge
 
       state :root do
         rule(/^ .*\n/, Text)
+        rule(/^---\n/, Text)
         rule(/^\+.*\n/, Generic::Inserted)
         rule(/^-+.*\n/, Generic::Deleted)
         rule(/^!.*\n/, Generic::Strong)


### PR DESCRIPTION
Deleted lines were no longer highlighted properly :(

<img width="615" alt="screen shot 2015-07-30 at 13 59 29" src="https://cloud.githubusercontent.com/assets/159434/8982582/372e15fe-36c3-11e5-82ff-af71ebf00d65.png">

The tokens now match those of Rugments: https://bitbucket.org/birkenfeld/pygments-main/src/1835fdd773a43477c51d5d4242ffee03e65aa15a/pygments/lexers/diff.py?at=default 

cc @rumpelsepp 