### PR TITLE
Add elisp as an alias for common-lisp.

### DIFF
--- a/lib/rouge/lexers/common_lisp.rb
+++ b/lib/rouge/lexers/common_lisp.rb
@@ -6,7 +6,7 @@ module Rouge
       title "Common Lisp"
       desc "The Common Lisp variant of Lisp (common-lisp.net)"
       tag 'common_lisp'
-      aliases 'cl', 'common-lisp'
+      aliases 'cl', 'common-lisp', 'elisp', 'emacs-lisp'
 
       filenames '*.cl', '*.lisp', '*.el' # used for Elisp too
       mimetypes 'text/x-common-lisp'


### PR DESCRIPTION
Since [common-lisp also supports elisp](https://github.com/jneen/rouge/blob/master/lib/rouge/lexers/common_lisp.rb#L11), we should have an alias for that.