### PR TITLE
Extended line numbering for HTML formatter and cast formatter options read from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,44 @@ Rouge::Theme.find('base16.light').render(scope: '.highlight')
 
 ### Full options
 #### Formatter options
-##### css_class: 'highlight'
+##### HTML formatter
+###### css_class: 'highlight'
 Apply a class to the syntax-highlighted output. Set to false to not apply any css class.
 
-##### line_numbers: false
+###### line_numbers: false
 Generate line numbers.
 
-##### start_line: 1
-Index to start line numbers.
+Valued to:
+* `false`, lines are not numbered
+* `true` or `:table`, lines are numbered by wrapping the code into the second column of a one row `<table>`. The first column will contain a `pre` tag with line numbers.
+* `:csscounters`, each line is wrapped into a `span` element of class `line_css_class` to be handled by CSS counters as below:
 
-##### inline_theme: nil
+```sass
+pre {
+  padding-left: 2.5em;
+  counter-reset: code;
+  span.line {
+    display: block;
+    counter-increment: code;
+    white-space: pre;
+    &:before {
+      content: counter(code);
+      float: left;
+      margin-left: -2.5em;
+      width: 2em;
+      text-align: right;
+    }
+  }
+}
+```
+
+###### line_css_class: 'line'
+The CSS class name to give to the `span` tag which wraps a line. Only when `line_numbers` = `:csscounters`.
+
+###### start_line: 1
+Index to start line numbers. Only when `line_numbers` = `true` or `:table`.
+
+###### inline_theme: nil
 A `Rouge::CSSTheme` used to highlight the output with inline styles instead of classes. Allows string inputs (separate mode with a dot):
 
 ```
@@ -52,8 +80,12 @@ A `Rouge::CSSTheme` used to highlight the output with inline styles instead of c
    base16.dark base16.light base16.solarized base16.monokai]
 ```
 
-##### wrap: true
+###### wrap: true
 Wrap the highlighted content in a container. Defaults to `<pre><code>`, or `<div>` if line numbers are enabled.
+
+##### Terminal formatter
+###### theme: Themes::ThankfulEyes
+A `Rouge::Theme` used to highlight output.
 
 #### Lexer options
 ##### debug: false

--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -42,11 +42,6 @@ load load_dir.join('rouge/template_lexer.rb')
 
 Dir.glob(load_dir.join('rouge/lexers/*.rb')).each { |f| load f }
 
-load load_dir.join('rouge/formatter.rb')
-load load_dir.join('rouge/formatters/html.rb')
-load load_dir.join('rouge/formatters/terminal256.rb')
-load load_dir.join('rouge/formatters/null.rb')
-
 load load_dir.join('rouge/theme.rb')
 load load_dir.join('rouge/themes/thankful_eyes.rb')
 load load_dir.join('rouge/themes/colorful.rb')
@@ -55,3 +50,8 @@ load load_dir.join('rouge/themes/github.rb')
 load load_dir.join('rouge/themes/monokai.rb')
 load load_dir.join('rouge/themes/molokai.rb')
 load load_dir.join('rouge/themes/monokai_sublime.rb')
+
+load load_dir.join('rouge/formatter.rb')
+load load_dir.join('rouge/formatters/html.rb')
+load load_dir.join('rouge/formatters/terminal256.rb')
+load load_dir.join('rouge/formatters/null.rb')

--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -249,7 +249,8 @@ module Rouge
         formatter_class = Formatter.find(opts[:formatter]) \
           or error! "unknown formatter #{opts[:formatter]}"
 
-        @formatter = formatter_class.new(opts[:formatter_opts])
+        @formatter = formatter_class.new
+        @formatter.set_options_from_strings(opts[:formatter_opts])
       end
 
       def run

--- a/lib/rouge/formatter.rb
+++ b/lib/rouge/formatter.rb
@@ -15,6 +15,58 @@ module Rouge
       @tag = tag
     end
 
+    # @private
+    class << self
+      def options
+        @options ||= {}
+      end
+    end
+
+    # @private
+    class Option < Struct.new(:klass, :default)
+    end
+
+    # Declare a Formatter option
+    def self.formatter_option(name, klass, default)
+      options[name] = Option.new(klass, default)
+    end
+
+    def initialize(opts = {})
+      self.class.options.each_pair do |k,o|
+        v = opts.fetch(k, o.default)
+        v = Theme.find(v) if o.klass.ancestors.include?(Theme) && v.is_a?(String)
+        instance_variable_set("@#{k}", v)
+      end
+    end
+
+    # Helper for CLI
+    def set_options_from_strings(opts)
+      opts.each_pair do |k,v|
+        next unless self.class.options.key? k
+        case
+        when Symbol == self.class.options[k].klass
+          v = v.to_sym
+        when Fixnum == self.class.options[k].klass
+          v = v.to_i
+        when [ TrueClass, FalseClass ].include?(self.class.options[k].klass)
+          v = %w(true on 1).include? v
+        when self.class.options[k].klass.ancestors.include?(Theme)
+          v = Theme.find(v)
+        end
+        instance_variable_set("@#{k}", v)
+      end
+    end
+
+    # Define a formatter option
+    def set_option(name, value)
+      instance_variable_set("@#{name}", value)
+    end
+
+    # Get value of a formatter option
+    def get_option(name)
+      instance_variable_get("@#{name}")
+    end
+
     # Find a formatter class given a unique tag.
     def self.find(tag)
       REGISTRY[tag]

--- a/lib/rouge/formatters/terminal256.rb
+++ b/lib/rouge/formatters/terminal256.rb
@@ -9,12 +9,12 @@ module Rouge
       # @private
       attr_reader :theme
 
+      formatter_option :theme, Theme, Themes::ThankfulEyes
 
       # @option opts :theme
       #   (default is thankful_eyes) the theme to render with.
       def initialize(opts={})
-        @theme = opts[:theme] || 'thankful_eyes'
-        @theme = Theme.find(@theme) if @theme.is_a? String
+        super
       end
 
       def stream(tokens, &b)

--- a/lib/rouge/plugins/redcarpet.rb
+++ b/lib/rouge/plugins/redcarpet.rb
@@ -18,7 +18,7 @@ module Rouge
         end
 
         formatter = rouge_formatter(lexer)
-        formatter.format(lexer.lex(code))
+        formatter.format(lexer.lex(code.chomp)) # remove the trailing line before ending ``` let by redcarpet
       end
 
       # override this method for custom formatting behavior

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -24,7 +24,7 @@ describe Rouge::Formatters::HTML do
       style Name, :bold => true
     end
 
-    let(:options) { { :inline_theme => InlineTheme.new, :wrap => false } }
+    let(:options) { { :inline_theme => InlineTheme, :wrap => false } }
 
     let(:output) {
       subject.format([[Token['Name'], 'foo']])
@@ -32,6 +32,15 @@ describe Rouge::Formatters::HTML do
 
     it 'inlines styles given a theme' do
       assert { output == '<span style="font-weight: bold">foo</span>' }
+    end
+  end
+
+  describe 'css counters line numbers' do
+    let(:options) { { :line_numbers => :csscounters, :line_css_class => 'ln', :wrap => false } }
+    let(:output) { subject.format([[Token['Name'], "abc\ndef"]]) }
+
+    it 'generates proper output for line_numbers = :counters' do
+      assert { output == "<span class=\"ln\"><span class=\"n\">abc\n</span></span><span class=\"ln\"><span class=\"n\">def</span></span>" }
     end
   end
 


### PR DESCRIPTION
* line_number option can be a symbol to choose between:
    + a line numbering based on a table as before with `true` (`true` is still valid, `:table` can also be used)
    + handled with CSS3 counters (see comment of Rouge::Formatter::HTML.new or README.md) when valued to `:csscounters`
    + `false` (still default) to disable it
* formatter options read from CLI remains String instead of being converted to Fixnum, boolean or whatever and are ignored at best (like wrap) or trigger an error (start_line throws a `String can't be coerced into Fixnum`)
* remove trailing line of input from redcarpet plugin (the one just before final \`\`\`)