### PR TITLE
Revoke Rust's claim to the `.rc` file extension

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -7,8 +7,7 @@ module Rouge
       desc 'The Rust programming language (rust-lang.org)'
       tag 'rust'
       aliases 'rs'
-      # TODO: *.rc conflicts with the rc shell...
-      filenames '*.rs', '*.rc'
+      filenames '*.rs'
       mimetypes 'text/x-rust'
 
       def self.analyze_text(text)

--- a/spec/lexers/rust_spec.rb
+++ b/spec/lexers/rust_spec.rb
@@ -8,7 +8,6 @@ describe Rouge::Lexers::Rust do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.rs'
-      assert_guess :filename => 'foo.rc'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
According to rust-lang/rust#1512, the "`.rc`" extension could be removed from rouge's possible filenames for the rust language :)

For example, it would help with the "`.rc`" files which are shell files (in my case, those "`.rc`" files even have a "`bash`" shebang, but they are still not recognized by the shell lexer).

BTW, I use [gitlab 7.14 which now uses rouge](https://about.gitlab.com/2015/08/22/gitlab-7-14-released/): that's how I stumbled upon your code.