### PR TITLE
The Shell lexer is included twice, which results in warnings about its…

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -149,4 +149,4 @@ module Rouge
       end
     end
   end
-end
+end unless defined?(Rouge::Lexers::Shell)


### PR DESCRIPTION
…constants being redefined. This checks for a prior definition before creating the class