### PR TITLE
Fix bug in Literal type definition

### DIFF
--- a/lib/rouge/lexers/common_lisp.rb
+++ b/lib/rouge/lexers/common_lisp.rb
@@ -270,7 +270,7 @@ module Rouge
 
         # arrays and structures
         rule /(#(?:\d+a|s))(\()/i do
-          groups Literal::Other, Punctuation
+          groups Literal::String::Other, Punctuation
           push :root
         end
 

--- a/spec/visual/samples/common_lisp
+++ b/spec/visual/samples/common_lisp
@@ -1202,3 +1202,5 @@ Henry Baker:
 
 (unless (clos::funcallable-instance-p #'clos::class-name)
   (fmakunbound 'clos::class-name))
+
+"CONSP" XXX: (SINGLE-FLOAT-VALUE #.ext::single-float-negative-infinity #S(C::VV :EXT:LOCATION 0 :C::USED-P NIL :C::PERMANENT-P T :C::VALUE #.ext::single-float-negative-infinity))


### PR DESCRIPTION
This was causing an unknown type error using the Common LISP test case included.