### PR TITLE
New VimL example

### DIFF
--- a/lib/rouge/demos/viml
+++ b/lib/rouge/demos/viml
@@ -1,5 +1,14 @@
-set encoding=utf-8
-
-filetype off
-call pathogen#runtime_append_all_bundles()
-filetype plugin indent on
+function! s:Make(dir, make, format, name) abort
+  let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd' : 'cd'
+  let cwd = getcwd()
+  let [mp, efm, cc] = [&l:mp, &l:efm, get(b:, 'current_compiler', '')]
+  try
+    execute cd fnameescape(dir)
+    let [&l:mp, &l:efm, b:current_compiler] = [a:make, a:format, a:compiler]
+    execute (exists(':Make') == 2 ? 'Make' : 'make')
+  finally
+    let [&l:mp, &l:efm, b:current_compiler] = [mp, efm, cc]
+    if empty(cc) | unlet! b:current_compiler | endif
+    execute cd fnameescape(cwd)
+  endtry
+endfunction


### PR DESCRIPTION
FWIW This is a pattern for wrapping up dispatch.vim while still leveraging plain `:make` if it is unavailable.