### PR TITLE
fix python "raise from" and "yield from"

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -85,6 +85,16 @@ module Rouge
           push :classname
         end
 
+        rule /(yield)((?:\s|\\\s)+)/ do
+           groups Keyword, Text
+           push :raise
+        end
+
+        rule /(raise)((?:\s|\\\s)+)/ do
+           groups Keyword, Text
+           push :raise
+        end
+
         rule /(from)((?:\s|\\\s)+)/ do
           groups Keyword::Namespace, Text
           push :fromimport
@@ -139,6 +149,19 @@ module Rouge
 
       state :classname do
         rule identifier, Name::Class, :pop!
+      end
+
+      state :raise do
+        rule /from\b/, Keyword
+        rule /raise\b/, Keyword
+        rule /yield\b/, Keyword
+        rule /\n/, Text, :pop!
+        rule /;/, Punctuation, :pop!
+        mixin :root
+      end
+
+      state :yield do
+        mixin :raise
       end
 
       state :import do


### PR DESCRIPTION
prevent :fromimport from activating in the wrong places.

This is for Python 3 code, but it doesn't break Python 2 parsing.