### PR TITLE
Add indirect declaration as in Swift 2

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -22,7 +22,7 @@ module Rouge
       )
 
       declarations = Set.new %w(
-        class deinit enum extension final func import init internal lazy let optional private protocol public required static struct subscript typealias var dynamic
+        class deinit enum extension final func import init internal lazy let optional private protocol public required static struct subscript typealias var dynamic indirect
       )
 
       constants = Set.new %w(


### PR DESCRIPTION
Add `indirect` declaration in Swift 2

example

```swift
enum Tree<T>{
    case Leaf(T)
    indirect case Node(Tree,T,Tree)
}
```

or 

```swift
indirect enum Tree<T>{
    case Leaf(T)
    case Node(Tree,T,Tree)
}
```