### PR TITLE
Add protobuf lexer

### DIFF
--- a/lib/rouge/demos/protobuf
+++ b/lib/rouge/demos/protobuf
@@ -1,0 +1,5 @@
+message Person {
+  required string name = 1;
+  required int32 id = 2;
+  optional string email = 3;
+}

--- a/lib/rouge/lexers/protobuf.rb
+++ b/lib/rouge/lexers/protobuf.rb
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class Protobuf < RegexLexer
+      title 'Protobuf'
+      desc 'Google\'s language-neutral, platform-neutral, extensible mechanism for serializing structured data'
+      tag 'protobuf'
+      aliases 'proto'
+      filenames '*.proto'
+      mimetypes 'text/x-proto'
+
+      kw = /\b(ctype|default|extensions|import|max|oneof|option|optional|packed|repeated|required|returns|rpc|to)\b/
+      datatype = /\b(bool|bytes|double|fixed32|fixed64|float|int32|int64|sfixed32|sfixed64|sint32|sint64|string|uint32|uint64)\b/
+
+      state :root do
+        rule /[\s]+/, Text
+        rule /[,;{}\[\]()]/, Punctuation
+        rule /\/(\\\n)?\/(\n|(.|\n)*?[^\\]\n)/, Comment::Single
+        rule /\/(\\\n)?\*(.|\n)*?\*(\\\n)?\//, Comment::Multiline
+        rule kw, Keyword
+        rule datatype, Keyword::Type
+        rule /true|false/, Keyword::Constant
+        rule /(package)(\s+)/ do
+          groups Keyword::Namespace, Text
+          push :package
+        end
+
+        rule /(message|extend)(\s+)/ do
+          groups Keyword::Declaration, Text
+          push :message
+        end
+
+        rule /(enum|group|service)(\s+)/ do
+          groups Keyword::Declaration, Text
+          push :type
+        end
+
+        rule /".*?"/, Str
+        rule /'.*?'/, Str
+        rule /(\d+\.\d*|\.\d+|\d+)[eE][+-]?\d+[LlUu]*/, Num::Float
+        rule /(\d+\.\d*|\.\d+|\d+[fF])[fF]?/, Num::Float
+        rule /(\-?(inf|nan))\b/, Num::Float
+        rule /0x[0-9a-fA-F]+[LlUu]*/, Num::Hex
+        rule /0[0-7]+[LlUu]*/, Num::Oct
+        rule /\d+[LlUu]*/, Num::Integer
+        rule /[+-=]/, Operator
+        rule /([a-zA-Z_][\w.]*)([ \t]*)(=)/ do
+          groups Name::Attribute, Text, Operator
+        end
+        rule /[a-zA-Z_][\w.]*/, Name
+      end
+
+      state :package do
+          rule /[a-zA-Z_]\w*/, Name::Namespace, :pop!
+          rule (//) { pop! }
+      end
+
+      state :message do
+          rule /[a-zA-Z_]\w*/, Name::Class, :pop!
+          rule (//) { pop! }
+      end
+
+      state :type do
+          rule /[a-zA-Z_]\w*/, Name, :pop!
+          rule (//) { pop! }
+      end
+    end
+  end
+end

--- a/spec/lexers/protobuf_spec.rb
+++ b/spec/lexers/protobuf_spec.rb
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Protobuf do
+  let(:subject) { Rouge::Lexers::Protobuf.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.proto'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-proto'
+    end
+  end
+end

--- a/spec/visual/samples/protobuf
+++ b/spec/visual/samples/protobuf
@@ -1,0 +1,30 @@
+// See README.txt for information and build instructions.
+
+package tutorial;
+
+option java_package = "com.example.tutorial";
+option java_outer_classname = "AddressBookProtos";
+
+message Person {
+  required string name = 1;
+  required int32 id = 2;        // Unique ID number for this person.
+  optional string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    required string number = 1;
+    optional PhoneType type = 2 [default = HOME];
+  }
+
+  repeated PhoneNumber phone = 4;
+}
+
+// Our address book file is just one of these.
+message AddressBook {
+  repeated Person person = 1;
+}


### PR DESCRIPTION
Hi, I'm liking Rouge, but I could not find a lexer for Google Protocol Buffers
The one in this pull request is pretty much an identical port of the dsls.ProtoBufLexer in pygments.
Hope i didn't make to many ruby mistakes..