### PR TITLE
Sort index page entries in visual test mode.

### DIFF
--- a/spec/visual/app.rb
+++ b/spec/visual/app.rb
@@ -56,7 +56,7 @@ class VisualTestApp < Sinatra::Application
 
 
   get '/' do
-    @samples = SAMPLES.entries.reject { |s| s.basename.to_s =~ /^\.|~$/ }
+    @samples = SAMPLES.entries.sort.reject { |s| s.basename.to_s =~ /^\.|~$/ }
     @samples.map!(&Rouge::Lexer.method(:find))
 
     erb :index


### PR DESCRIPTION
Pathname.entries() does not guarantee in which order the directory
entries are returned; in fact, that is completely OS-dependend, so if we
want the code snippets to be displayed in lexicograhpic order, we have
to sort the entries ourselfs.