### PR TITLE
Fix CPP identifier so that it can have '_'

### DIFF
--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -34,7 +34,7 @@ module Rouge
         ))
       end
 
-      id = /[a-zA-Z_][a-zA-Z0-9]*/
+      id = /[a-zA-Z_][a-zA-Z0-9_]*/
 
       prepend :root do
         # Offload C++ extensions, http://offload.codeplay.com/


### PR DESCRIPTION
The regular expression for identifying C++ identifiers presently allows underscore only as the first character. Underscore should possible as any other character in C++ identifier.