### PR TITLE
Add application/hal+json Mime Types

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -206,7 +206,8 @@ module Rouge
       desc "JavaScript Object Notation (json.org)"
       tag 'json'
       filenames '*.json'
-      mimetypes 'application/json', 'application/vnd.api+json'
+      mimetypes 'application/json', 'application/vnd.api+json',
+                'application/hal+json'
 
       # TODO: is this too much of a performance hit?  JSON is quite simple,
       # so I'd think this wouldn't be too bad, but for large documents this

--- a/spec/lexers/javascript_spec.rb
+++ b/spec/lexers/javascript_spec.rb
@@ -24,6 +24,7 @@ describe Rouge::Lexers::Javascript do
       assert_guess :mimetype => 'text/javascript'
       assert_guess Rouge::Lexers::JSON, :mimetype => 'application/json'
       assert_guess Rouge::Lexers::JSON, :mimetype => 'application/vnd.api+json'
+      assert_guess Rouge::Lexers::JSON, :mimetype => 'application/hal+json'
     end
 
     it 'guesses by source' do


### PR DESCRIPTION
Previously, the JSON Lexer did not accept the `application/hal+json` mime type. This change updates the Lexer and its tests to accept it.