### PR TITLE
Adding support for Ruby 2.3 heredocs

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -228,17 +228,17 @@ module Rouge
       end
 
       state :has_heredocs do
-        rule /(?<!\w)(<<-?)(["`']?)([a-zA-Z_]\w*)(\2)/ do |m|
+        rule /(?<!\w)(<<[-~]?)(["`']?)([a-zA-Z_]\w*)(\2)/ do |m|
           token Operator, m[1]
           token Name::Constant, "#{m[2]}#{m[3]}#{m[4]}"
-          @heredoc_queue << [m[1] == '<<-', m[3]]
+          @heredoc_queue << [['<<-', '<<~'].include?(m[1]), m[3]]
           push :heredoc_queue unless state? :heredoc_queue
         end
 
-        rule /(<<-?)(["'])(\2)/ do |m|
+        rule /(<<[-~]?)(["'])(\2)/ do |m|
           token Operator, m[1]
           token Name::Constant, "#{m[2]}#{m[3]}#{m[4]}"
-          @heredoc_queue << [m[1] == '<<-', '']
+          @heredoc_queue << [['<<-', '<<~'].include?(m[1]), '']
           push :heredoc_queue unless state? :heredoc_queue
         end
       end

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -153,6 +153,10 @@ A
 and this is the text of b
 B
 
+<<~END
+This is a Ruby 2.3 stripped heredoc
+END
+
 a = <<"EOF"
 This is a multiline #$here document
 terminated by EOF on a line by itself


### PR DESCRIPTION
This PR adds support for the new Ruby 2.3 heredocs syntax:

``` ruby
str = <<~END
  This is a stripped heredoc
END
```