### PR TITLE
Fix issue 360

### DIFF
--- a/lib/rouge/lexers/apache.rb
+++ b/lib/rouge/lexers/apache.rb
@@ -28,7 +28,7 @@ module Rouge
       end
 
       state :whitespace do
-        rule /\#.*?\n/, Comment
+        rule /\#.*/, Comment
         rule /\s+/m, Text
       end
 

--- a/lib/rouge/lexers/cmake.rb
+++ b/lib/rouge/lexers/cmake.rb
@@ -169,7 +169,7 @@ module Rouge
           groups BUILTIN_COMMANDS.include?(m[1]) ? Name::Builtin : Name::Function, Text, Punctuation
         end
 
-        rule /#.*(?:\r\n?|\n)/, Comment::Single
+        rule /#.*/, Comment::Single
 
         mixin :default
       end

--- a/lib/rouge/lexers/sql.rb
+++ b/lib/rouge/lexers/sql.rb
@@ -89,7 +89,7 @@ module Rouge
 
       state :root do
         rule /\s+/m, Text
-        rule /--.*?\n/, Comment::Single
+        rule /--.*/, Comment::Single
         rule %r(/\*), Comment::Multiline, :multiline_comments
         rule /\d+/, Num::Integer
         rule /'/, Str::Single, :single_string

--- a/spec/lexers/apache_spec.rb
+++ b/spec/lexers/apache_spec.rb
@@ -26,5 +26,9 @@ describe Rouge::Lexers::Apache do
     it 'lexes case insensitively directives' do
       assert_tokens_equal 'setenv foo bar', ['Name.Class', 'setenv'], ['Text', ' foo bar']
     end
+
+    it 'recognizes one line comment on last line even when not terminated by a new line (#360)' do
+      assert_tokens_equal '# comment', ['Comment', '# comment']
+    end
   end
 end

--- a/spec/lexers/cmake_spec.rb
+++ b/spec/lexers/cmake_spec.rb
@@ -13,4 +13,12 @@ describe Rouge::Lexers::CMake do
       assert_guess :mimetype => 'text/x-cmake'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'recognizes one line comment on last line even when not terminated by a new line (#360)' do
+      assert_tokens_equal '# comment', ['Comment.Single', '# comment']
+    end
+  end
 end

--- a/spec/lexers/sql_spec.rb
+++ b/spec/lexers/sql_spec.rb
@@ -14,4 +14,12 @@ describe Rouge::Lexers::SQL do
       assert_guess :mimetype => 'text/x-sql'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'recognizes one line comment on last line even when not terminated by a new line (#360)' do
+      assert_tokens_equal '-- comment', ['Comment.Single', '-- comment']
+    end
+  end
 end


### PR DESCRIPTION
Single comments are not recognized at end of file, without new line character behind.

Reported as #360 for the SQL lexer.

Backported to Apache and CMake lexers but some others lexers may also be affected.