### PR TITLE
PHTML files support

### DIFF
--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -7,7 +7,7 @@ module Rouge
       desc "The PHP scripting language (php.net)"
       tag 'php'
       aliases 'php', 'php3', 'php4', 'php5'
-      filenames '*.php', '*.php[345t]',
+      filenames '*.php', '*.php[345t]','*.phtml',
                 # Support Drupal file extensions, see:
                 # https://github.com/gitlabhq/gitlabhq/issues/8900
                 '*.module', '*.inc', '*.profile', '*.install', '*.test'


### PR DESCRIPTION
Magento uses `*.phtml` files for templates. I test in GitLab, if `php` syntax highlighting works fine for this type of files/syntax and think it's good enough. So the simple add of extra one extension should be all necessary work to do.

Syntax highlight sample:
![Code sample](http://i.imgur.com/iUIz5KD.png)