### PR TITLE
Conflict on token names when caching escape sequences (terminal256 formatter)

### DIFF
--- a/lib/rouge/formatters/terminal256.rb
+++ b/lib/rouge/formatters/terminal256.rb
@@ -155,7 +155,7 @@ module Rouge
     # private
       def escape_sequence(token)
         @escape_sequences ||= {}
-        @escape_sequences[token.name] ||=
+        @escape_sequences[token.qualname] ||=
           EscapeSequence.new(get_style(token))
       end
 


### PR DESCRIPTION
As Token::name returns only the last part of token's name, the terminal256 formatter shouldn't use it to cache escape sequences.

Actually, there is some conflicts like:
* Comment.Single and String.Single both known as :Single
* Other, Name.Other, String.Other, Number.Other as :Other

So the style (escape sequence) for the first token of a given type will be reused for the others.

Eg, with:
```php
<?php
echo 'bar';
```

The string bar (String.Single) is highlighted, by the terminal256 formatter like the comment (Comment.Single) above. And vice-versa if we invert these two instructions.