### PR TITLE
Use "$" pattern for single line comment in CoffeeScript.

### DIFF
--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -43,7 +43,7 @@ module Rouge
       state :comments_and_whitespace do
         rule /\s+/m, Text
         rule /###.*?###/m, Comment::Multiline
-        rule /#.*?\n/, Comment::Single
+        rule /#.*$/, Comment::Single
       end
 
       state :multiline_regex do


### PR DESCRIPTION
Fixes #369

I'm using the same pattern that we use for single line comments in Ruby: https://github.com/jneen/rouge/blob/d989f18440335b5098c6955a219b9e6abed8da35/lib/rouge/lexers/ruby.rb#L151