### PR TITLE
Support for C11/C++11 syntax

### DIFF
--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -19,6 +19,9 @@ module Rouge
           auto break case const continue default do else enum extern
           for goto if register restricted return sizeof static struct
           switch typedef union volatile virtual while
+
+          _Alignas _Alignof _Atomic _Generic _Imaginary
+          _Noreturn _Static_assert _Thread_local
         )
       end
 
@@ -38,6 +41,8 @@ module Rouge
           int_fast64_t uint_fast8_t uint_fast16_t uint_fast32_t
           uint_fast64_t intptr_t uintptr_t intmax_t
           uintmax_t
+
+          char16_t char32_t
         )
       end
 

--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -101,8 +101,8 @@ module Rouge
 
       state :statements do
         mixin :whitespace
-        rule /L?"/, Str, :string
-        rule %r(L?'(\\.|\\[0-7]{1,3}|\\x[a-f0-9]{1,2}|[^\\'\n])')i, Str::Char
+        rule /(u8|u|U|L)?"/, Str, :string
+        rule %r((u8|u|U|L)?'(\\.|\\[0-7]{1,3}|\\x[a-f0-9]{1,2}|[^\\'\n])')i, Str::Char
         rule %r((\d+[.]\d*|[.]?\d+)e[+-]?\d+[lu]*)i, Num::Float
         rule %r(\d+e[+-]?\d+[lu]*)i, Num::Float
         rule /0x[0-9a-f]+[lu]*/i, Num::Hex

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -62,7 +62,7 @@ module Rouge
         rule /0[0-7]('?[0-7])*[lu]*/i, Num::Oct
         rule /#{dq}[lu]*/i, Num::Integer
         rule /\bnullptr\b/, Name::Builtin
-        rule /(?:u8|u|U|L)?R"([a-zA-Z0-9_{}\[\]#<>%:;.?*\+\-\/\^&|~!=,"']{,16})\(.*?\)\1"/, Str
+        rule /(?:u8|u|U|L)?R"([a-zA-Z0-9_{}\[\]#<>%:;.?*\+\-\/\^&|~!=,"']{,16})\(.*?\)\1"/m, Str
       end
 
       state :classname do

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -24,6 +24,15 @@ module Rouge
           friend mutable namespace new operator private protected public
           reinterpret_cast restrict static_cast template this throw
           throws typeid typename using virtual
+
+          alignas alignof constexpr decltype noexcept static_assert
+          thread_local try
+        ))
+      end
+
+      def self.keywords_type
+        @keywords_type ||= super + Set.new(%w(
+          bool
         ))
       end
 
@@ -52,6 +61,7 @@ module Rouge
         rule /0x\h('?\h)*[lu]*/i, Num::Hex
         rule /0[0-7]('?[0-7])*[lu]*/i, Num::Oct
         rule /#{dq}[lu]*/i, Num::Integer
+        rule /\bnullptr\b/, Name::Builtin
       end
 
       state :classname do

--- a/lib/rouge/lexers/cpp.rb
+++ b/lib/rouge/lexers/cpp.rb
@@ -62,6 +62,7 @@ module Rouge
         rule /0[0-7]('?[0-7])*[lu]*/i, Num::Oct
         rule /#{dq}[lu]*/i, Num::Integer
         rule /\bnullptr\b/, Name::Builtin
+        rule /(?:u8|u|U|L)?R"([a-zA-Z0-9_{}\[\]#<>%:;.?*\+\-\/\^&|~!=,"']{,16})\(.*?\)\1"/, Str
       end
 
       state :classname do

--- a/spec/visual/samples/cpp
+++ b/spec/visual/samples/cpp
@@ -2,6 +2,29 @@ int quote_delims = 100'000'000
 int float_delims = 100.00'00
 int hex_delims = 0xFF'Fa12
 
+// string literal with encoding-prefix
+char str1[] = u8"UTF-8 string";
+char16_t str2[] = u"UTF-16 string";
+char32_t str3[] = U"UTF-32 string";
+
+// Raw string literal
+char raw_str1[] = R"(foo
+bar
+baz)";
+char raw_str2[] = R"delim(\w+ \d+)delim";
+char16_t raw_str3[] = uR"(\w+ \d+)";
+
+// try-block
+try {
+  throw std::runtime_error("Runtime error!");
+} catch (std::exception& e) {
+  std::cerr << e.what() << std::endl;
+}
+
+constexpr int factorial(int n) {
+  return n > 0 ? n * factorial(n - 1) : 1;
+}
+
 /* foo */ #if 0
  this is commented
 #endif


### PR DESCRIPTION
This PR adds support for C11/C++11 syntax.

* Some keywords
```cpp
// C11
_Alignas _Alignof _Atomic _Generic _Imaginary _Noreturn _Static_assert _Thread_local
char16_t char32_t

// C++11
alignas alignof constexpr decltype noexcept static_assert thread_local

// missing C++ keywords
bool try
```

* UTF-8, UTF-16, UTF-32 encoding prefixes (C11/C++11)
```c
char s1[] = u8"UTF-8 string";
char16_t s2[] = u"UTF-16 string";
char32_t s3[] = U"UTF-32 string";
```

* Raw string literal (C++11)
```cpp
char s1[] = R"(\w+ \d+)";
char s2[] = R"delim(\w+ \d+)delim";
char16_t s3[] = uR"(\w+ \d+)";
```