### PR TITLE
Swift 2.2 changes

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -22,7 +22,7 @@ module Rouge
       )
 
       declarations = Set.new %w(
-        class deinit enum extension final func import init internal lazy let optional private protocol public required static struct subscript typealias var dynamic indirect
+        class deinit enum extension final func import init internal lazy let optional private protocol public required static struct subscript typealias var dynamic indirect associatedtype
       )
 
       constants = Set.new %w(
@@ -85,6 +85,10 @@ module Rouge
         end
         
         rule /#available\([^)]+\)/, Keyword::Declaration
+        
+        rule /(#selector\()([^)]+?(?:[(].*?[)])?)(\))/ do
+          groups Keyword::Declaration, Name::Function, Keyword::Declaration
+        end
 
         rule /(let|var)\b(\s*)(#{id})/ do
           groups Keyword, Text, Name::Variable

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -98,8 +98,8 @@ module Rouge
           end
         end
         
-        rule /as[?!]?/, Keyword
-        rule /try[!]?/, Keyword
+        rule /as[?!]?(?=\s)/, Keyword
+        rule /try[!]?(?=\s)/, Keyword
 
         rule /(#?(?!default)(?![[:upper:]])#{id})(\s*)(:)/ do
           groups Name::Variable, Text, Punctuation

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -325,4 +325,25 @@ enum State: Equatable {
     */
 #endif
 
+protocol Protocol {
+    associatedtype AssociatedType
+    typealias TypeAlias
+}
+
+// keywords acceptable as argument names now:
+NSURLProtectionSpace(host: "somedomain.com", port: 443, protocol: "https", realm: "Some Domain", authenticationMethod: "Basic")
+
+let fn1 = someView.insertSubview(_:at:)
+let fn2 = someView.insertSubview(_:aboveSubview:)
+
+#if swift(>=2.2)
+  // Only this code will be parsed in Swift 3
+  func foo(x: Int) -> (y: Int) -> () {}
+#else
+  // This code is ignored entirely.
+  func foo(x: Int)(y: Int) {}
+#endif
+
+let sel = foo(#selector(insertSubview(_:aboveSubview:)))
+
 foo() // end-of-file comment


### PR DESCRIPTION
- adds `associatedtype` keyword
- adds `#selector(objcselector)` syntax
- fixes idents starting with "as", "try" being colored for `as` and `try` operators