### PR TITLE
Improve R syntax highlighting

### DIFF
--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -36,21 +36,21 @@ module Rouge
 
         rule /%[^%]*?%/, Operator
 
+        rule /0[xX][a-fA-F0-9]+([pP][0-9]+)?[Li]?/, Num::Hex
+        rule /[+-]?(\d+([.]\d+)?|[.]\d+)([eE][+-]?\d+)?[Li]?/,
+          Num
+
         rule /[a-zA-Z.]([a-zA-Z_][\w.]*)?/ do |m|
           if KEYWORDS.include? m[0]
             token Keyword
           elsif KEYWORD_CONSTANTS.include? m[0]
             token Keyword::Constant
           elsif BUILTIN_CONSTANTS.include? m[0]
-            token Name::Constant
+            token Name::Builtin
           else
             token Name
           end
         end
-
-        rule /0[xX][a-fA-F0-9]+([pP][0-9]+)?[Li]?/, Num::Hex
-        rule /[+-]?(\d+([.]\d+)?|[.]\d+)([eE][+-]?\d+)?[Li]?/,
-          Num
 
         rule /[\[\]{}();,]/, Punctuation
 

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -33,7 +33,7 @@ module Rouge
           end
         end
 
-        rule /`.*?`/, Name
+        rule /`[^`]+?`/, Name
         rule /'(\\.|.)*?'/m, Str::Single
         rule /"(\\.|.)*?"/m, Str::Double
 

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -34,7 +34,7 @@ module Rouge
         rule /\b(NULL|Inf|TRUE|FALSE|NaN)(?!\.)\b/, Keyword::Constant
         rule /\bNA(_(integer|real|complex|character)_)?\b/,
           Keyword::Constant
-        rule /\b[TF]\b/, Keyword::Variable
+        rule /\b[TF]\b/, Name::Constant
 
         rule /%[^%]*?%/, Operator
 

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -38,7 +38,7 @@ module Rouge
 
         rule /%[^%]*?%/, Operator
 
-        rule /[a-zA-Z.][\w.]*/ do |m|
+        rule /[a-zA-Z.]([a-zA-Z_][\w.]*)?/ do |m|
           if self.class.keywords.include? m[0]
             token Keyword
           else

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -25,13 +25,6 @@ module Rouge
       state :root do
         rule /#.*?\n/, Comment::Single
         rule /\s+/m, Text
-        rule /[.]?[a-zA-Z_][\w.]*/ do |m|
-          if self.class.keywords.include? m[0]
-            token Keyword
-          else
-            token Name
-          end
-        end
 
         rule /`[^`]+?`/, Name
         rule /'(\\.|.)*?'/m, Str::Single
@@ -41,6 +34,14 @@ module Rouge
         rule /\bNA(_(integer|real|complex|character)_)?\b/,
           Keyword::Constant
         rule /\b[TF]\b/, Keyword::Variable
+
+        rule /[.]?[a-zA-Z_][\w.]*/ do |m|
+          if self.class.keywords.include? m[0]
+            token Keyword
+          else
+            token Name
+          end
+        end
 
         rule /0[xX][a-fA-F0-9]+([pP][0-9]+)?[Li]?/, Num::Hex
         rule /[+-]?(\d+([.]\d+)?|[.]\d+)([eE][+-]?\d+)?[Li]?/,

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -31,7 +31,7 @@ module Rouge
         rule /'(\\.|.)*?'/m, Str::Single
         rule /"(\\.|.)*?"/m, Str::Double
 
-        rule /\b(NULL|Inf|TRUE|FALSE|NaN)\b/, Keyword::Constant
+        rule /\b(NULL|Inf|TRUE|FALSE|NaN)(?!\.)\b/, Keyword::Constant
         rule /\bNA(_(integer|real|complex|character)_)?\b/,
           Keyword::Constant
         rule /\b[TF]\b/, Keyword::Variable

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -7,7 +7,7 @@ module Rouge
       desc 'The R statistics language (r-project.org)'
       tag 'r'
       aliases 'r', 'R', 's', 'S'
-      filenames '*.R', '.Rhistory', '.Rprofile'
+      filenames '*.R', '*.r', '.Rhistory', '.Rprofile'
       mimetypes 'text/x-r-source', 'text/x-r', 'text/x-R'
 
       mimetypes 'text/x-r', 'application/x-r'

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -23,7 +23,7 @@ module Rouge
       state :root do
         rule /#'.*?\n/, Comment::Doc
         rule /#.*?\n/, Comment::Single
-        rule /\s+/m, Text
+        rule /\s+/m, Text::Whitespace
 
         rule /`[^`]+?`/, Name
         rule /'(\\.|.)*?'/m, Str::Single

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -49,7 +49,7 @@ module Rouge
         rule /[\[\]{}();,]/, Punctuation
 
         rule %r([-<>?*+^/!=~$@:%&|]), Operator
-        rule /[.][.][.]/, Keyword
+        rule /[.][.][.]/, Name
       end
     end
   end

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -14,7 +14,7 @@ module Rouge
 
       def self.keywords
         @keywords ||= %w(
-          if else for while repeat in next break return switch function
+          if else for while repeat in next break switch function
         )
       end
 

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -23,6 +23,7 @@ module Rouge
       end
 
       state :root do
+        rule /#'.*?\n/, Comment::Doc
         rule /#.*?\n/, Comment::Single
         rule /\s+/m, Text
 

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -12,11 +12,9 @@ module Rouge
 
       mimetypes 'text/x-r', 'application/x-r'
 
-      def self.keywords
-        @keywords ||= %w(
-          if else for while repeat in next break switch function
-        )
-      end
+      KEYWORDS = %w(if else for while repeat in next break switch function)
+
+      BUILTIN_CONSTANTS = %w(LETTERS letters month.abb month.name pi T F)
 
       def self.analyze_text(text)
         return 1 if text.shebang? 'Rscript'
@@ -34,13 +32,14 @@ module Rouge
         rule /\b(NULL|Inf|TRUE|FALSE|NaN)(?!\.)\b/, Keyword::Constant
         rule /\bNA(_(integer|real|complex|character)_)?\b/,
           Keyword::Constant
-        rule /\b[TF]\b/, Name::Constant
 
         rule /%[^%]*?%/, Operator
 
         rule /[a-zA-Z.]([a-zA-Z_][\w.]*)?/ do |m|
-          if self.class.keywords.include? m[0]
+          if KEYWORDS.include? m[0]
             token Keyword
+          elsif BUILTIN_CONSTANTS.include? m[0]
+            token Name::Constant
           else
             token Name
           end

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -33,7 +33,7 @@ module Rouge
           end
         end
 
-        rule /`.*?`/, Str::Backtick
+        rule /`.*?`/, Name
         rule /'(\\.|.)*?'/m, Str::Single
         rule /"(\\.|.)*?"/m, Str::Double
 

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -12,7 +12,7 @@ module Rouge
 
       mimetypes 'text/x-r', 'application/x-r'
 
-      KEYWORDS = %w(if else for while repeat in next break switch function)
+      KEYWORDS = %w(if else for while repeat in next break function)
 
       KEYWORD_CONSTANTS = %w(
         NULL Inf TRUE FALSE NaN NA

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -21,6 +21,28 @@ module Rouge
 
       BUILTIN_CONSTANTS = %w(LETTERS letters month.abb month.name pi T F)
 
+      # These are all the functions in `base` that are implemented as a
+      # `.Primitive`, minus those functions that are also keywords.
+      PRIMITIVE_FUNCTIONS = %w(
+        abs acos acosh all any anyNA Arg as.call as.character
+        as.complex as.double as.environment as.integer as.logical
+        as.null.default as.numeric as.raw asin asinh atan atanh attr
+        attributes baseenv browser c call ceiling class Conj cos cosh
+        cospi cummax cummin cumprod cumsum digamma dim dimnames
+        emptyenv exp expression floor forceAndCall gamma gc.time
+        globalenv Im interactive invisible is.array is.atomic is.call
+        is.character is.complex is.double is.environment is.expression
+        is.finite is.function is.infinite is.integer is.language
+        is.list is.logical is.matrix is.na is.name is.nan is.null
+        is.numeric is.object is.pairlist is.raw is.recursive is.single
+        is.symbol lazyLoadDBfetch length lgamma list log max min
+        missing Mod names nargs nzchar oldClass on.exit pos.to.env
+        proc.time prod quote range Re rep retracemem return round
+        seq_along seq_len seq.int sign signif sin sinh sinpi sqrt
+        standardGeneric substitute sum switch tan tanh tanpi tracemem
+        trigamma trunc unclass untracemem UseMethod xtfrm
+      )
+
       def self.analyze_text(text)
         return 1 if text.shebang? 'Rscript'
       end
@@ -39,6 +61,12 @@ module Rouge
         rule /0[xX][a-fA-F0-9]+([pP][0-9]+)?[Li]?/, Num::Hex
         rule /[+-]?(\d+([.]\d+)?|[.]\d+)([eE][+-]?\d+)?[Li]?/,
           Num
+
+        # Only recognize built-in functions when they are actually used as a
+        # function call, i.e. followed by an opening parenthesis.
+        # `Name::Builtin` would be more logical, but is usually not
+        # highlighted specifically; thus use `Name::Function`.
+        rule /\b(?<!.)(#{PRIMITIVE_FUNCTIONS.join('|')})(?=\()/, Name::Function
 
         rule /[a-zA-Z.]([a-zA-Z_][\w.]*)?/ do |m|
           if KEYWORDS.include? m[0]

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -14,6 +14,11 @@ module Rouge
 
       KEYWORDS = %w(if else for while repeat in next break switch function)
 
+      KEYWORD_CONSTANTS = %w(
+        NULL Inf TRUE FALSE NaN NA
+        NA_integer_ NA_real_ NA_complex_ NA_character_
+      )
+
       BUILTIN_CONSTANTS = %w(LETTERS letters month.abb month.name pi T F)
 
       def self.analyze_text(text)
@@ -29,15 +34,13 @@ module Rouge
         rule /'(\\.|.)*?'/m, Str::Single
         rule /"(\\.|.)*?"/m, Str::Double
 
-        rule /\b(NULL|Inf|TRUE|FALSE|NaN)(?!\.)\b/, Keyword::Constant
-        rule /\bNA(_(integer|real|complex|character)_)?\b/,
-          Keyword::Constant
-
         rule /%[^%]*?%/, Operator
 
         rule /[a-zA-Z.]([a-zA-Z_][\w.]*)?/ do |m|
           if KEYWORDS.include? m[0]
             token Keyword
+          elsif KEYWORD_CONSTANTS.include? m[0]
+            token Keyword::Constant
           elsif BUILTIN_CONSTANTS.include? m[0]
             token Name::Constant
           else

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -38,7 +38,7 @@ module Rouge
 
         rule /%[^%]*?%/, Operator
 
-        rule /[.]?[a-zA-Z_][\w.]*/ do |m|
+        rule /[a-zA-Z.][\w.]*/ do |m|
           if self.class.keywords.include? m[0]
             token Keyword
           else
@@ -53,7 +53,6 @@ module Rouge
         rule /[\[\]{}();,]/, Punctuation
 
         rule %r([-<>?*+^/!=~$@:%&|]), Operator
-        rule /[.][.][.]/, Name
       end
     end
   end

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -35,6 +35,8 @@ module Rouge
           Keyword::Constant
         rule /\b[TF]\b/, Keyword::Variable
 
+        rule /%[^%]*?%/, Operator
+
         rule /[.]?[a-zA-Z_][\w.]*/ do |m|
           if self.class.keywords.include? m[0]
             token Keyword

--- a/spec/lexers/r_spec.rb
+++ b/spec/lexers/r_spec.rb
@@ -8,6 +8,7 @@ describe Rouge::Lexers::R do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.R'
+      assert_guess :filename => 'bar.r'
       assert_guess :filename => '.Rhistory'
       assert_guess :filename => '.Rprofile'
     end

--- a/spec/visual/samples/r
+++ b/spec/visual/samples/r
@@ -42,6 +42,7 @@ NA_foo_ <- NULL
 1.23e-3
 1.23e3
 1.23e-3
+.25
 ## integer constants
 123L
 1.23L

--- a/spec/visual/samples/r
+++ b/spec/visual/samples/r
@@ -151,3 +151,12 @@ world!'
 
 ## Backtick strings
 `foo123 +!"bar'baz` <- 2 + 2
+
+## Roxygen
+
+#' A description
+#'
+#' Long description
+#' @param x the object
+#' @return A logical indicating whether \code{x == 0}
+is_zero = function (x) x == 0

--- a/spec/visual/samples/r
+++ b/spec/visual/samples/r
@@ -159,6 +159,14 @@ world!'
 `foo123 +!"bar'baz` <- 2 + 2
 x = ` ` % % 2
 
+## Builtin names
+
+LETTERS
+letters
+month.abb
+month.name
+pi
+
 ## Roxygen
 
 #' A description

--- a/spec/visual/samples/r
+++ b/spec/visual/samples/r
@@ -151,6 +151,7 @@ world!'
 
 ## Backtick strings
 `foo123 +!"bar'baz` <- 2 + 2
+x = ` ` % % 2
 
 ## Roxygen
 

--- a/spec/visual/samples/r
+++ b/spec/visual/samples/r
@@ -15,6 +15,8 @@ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV0123456789._a <- NULL
 0abc <- NULL
 .0abc <- NULL
 abc+cde <- NULL
+_ <- NULL
+_x <- NULL
 
 ## Reserved Words
 NA

--- a/spec/visual/samples/r
+++ b/spec/visual/samples/r
@@ -7,6 +7,9 @@
 abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV0123456789._a <- NULL
 .foo_ <- NULL
 ._foo <- NULL
+. <- NULL
+.. <- NULL
+... <- NULL
 
 ## Invalid names
 0abc <- NULL

--- a/spec/visual/samples/r
+++ b/spec/visual/samples/r
@@ -10,6 +10,7 @@ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV0123456789._a <- NULL
 . <- NULL
 .. <- NULL
 ... <- NULL
+c(T, F)
 
 ## Invalid names
 0abc <- NULL

--- a/spec/visual/samples/r
+++ b/spec/visual/samples/r
@@ -10,6 +10,7 @@ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV0123456789._a <- NULL
 . <- NULL
 .. <- NULL
 ... <- NULL
+c <- NULL
 c(T, F)
 
 ## Invalid names


### PR DESCRIPTION
This PR adds the following features to the R lexer:

* Recognition of filenames ending in lowercase `.r`
* Backtick delimited tokens are not strings, they are identifiers
* Fix recognition of reserved constants (used to be recognised as normal identifiers)
* `...` (and in fact any combination of dots in identifiers) is a valid name, and not a keyword
* Identifiers may not start with `_`
* Operators delimited by `%`…`%` are recognised, and may contain whitespace
* `return` isn’t a keyword in R, it’s a normal identifier
* Comments starting with `#'` are marked as doc comments

The following improvements are still outstanding:

* Recognise Roxygen directives within doc comments (not possible; see #388)
* [x] Highlight builtin functions (including `return`)?

A separate lexer should be added to support the various flavours (RMarkdown and TeX) of Knitr. This is beyond the scope of this PR.