### PR TITLE
Fix Python 3 multiline raise/from construct

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -87,7 +87,7 @@ module Rouge
 
         rule /(yield)((?:\s|\\\s)+)/ do
            groups Keyword, Text
-           push :raise
+           push :yield
         end
 
         rule /(raise)((?:\s|\\\s)+)/ do
@@ -151,10 +151,15 @@ module Rouge
         rule identifier, Name::Class, :pop!
       end
 
+      state :paren do
+        rule /\(/, Punctuation, :paren
+        rule /\)/, Punctuation, :pop!
+        mixin :root
+      end
+
       state :raise do
+        rule /\(/, Punctuation, :paren
         rule /from\b/, Keyword
-        rule /raise\b/, Keyword
-        rule /yield\b/, Keyword
         rule /\n/, Text, :pop!
         rule /;/, Punctuation, :pop!
         mixin :root

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -11,6 +11,13 @@ def lex(code, lexer):
                             'not a class')
         raise
 
+def test_multiline_raise_from(some_dict):
+    try:
+        some_dict["thing"]
+    except KeyError as err:
+        raise ValueError("'some_dict' must have a 'thing' key to be used "
+                         "by this function") from err
+
 # quotes in strings
 def foo():
     "it's working"


### PR DESCRIPTION
This fixes highlighting for code where the `from e` in a `raise Exception() from e` construct isn't on the same line as the `raise` statement.

Example:

``` python
try:
    print (1/0)
except Exception e:
    raise TypeError("multiline"
                    "string") from e
```

I've tested this with multiple Python files and it doesn't seem to break anything. The tests also all pass.

Maybe @mordervomubel (author of PR #324 where the code was added) can comment on why the `\n` rule was added - did it fix a specific case I didn't have in my test files?

Related to #3 

EDIT: As this commit is now gone, for reference, it just removed [this rule](https://github.com/jneen/rouge/blob/67d23be9241a0a2b39b4570819e321018ed2ce80/lib/rouge/lexers/python.rb#L158)
