### PR TITLE
Link to rouge-rails in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ Rouge is only for UTF-8 strings.  If you'd like to highlight a string with a dif
 * Middleman: [middleman-syntax](https://github.com/middleman/middleman-syntax) (@bhollis)
 * Middleman: [middleman-rouge][] (@Linuus)
 * RDoc: [rdoc-rouge][] (@zzak)
+* Rouge::Rails: [render code samples in your rails views][rouge-rails] (@jacobsimeon)
 
 [middleman-rouge]: https://github.com/Linuus/middleman-rouge
 [rdoc-rouge]: https://github.com/zzak/rdoc-rouge
+[rouge-rails]: https://github.com/jacobsimeon/rouge-rails
 
 ## Contributing
 


### PR DESCRIPTION
I thought it would be nice to add a link to the README for people who might be looking for a way to render code examples as partials in their rails apps.

https://github.com/jacobsimeon/rouge-rails

– Jacob Morris