### PR TITLE
Add a lexer for the Test Anything Protocol (TAP).

### DIFF
--- a/lib/rouge/demos/tap
+++ b/lib/rouge/demos/tap
@@ -1,0 +1,5 @@
+ok 1 - Input file opened
+not ok 2 - First line of the input valid
+ok 3 - Read the rest of the file
+not ok 4 - Summarized correctly # TODO Not written yet
+1..4

--- a/lib/rouge/lexers/tap.rb
+++ b/lib/rouge/lexers/tap.rb
@@ -1,10 +1,11 @@
 module Rouge
   module Lexers
     class Tap < RegexLexer
-      desc 'tap'
+      title 'TAP'
+      desc 'Test Anything Protocol'
       tag 'tap'
       aliases 'tap'
-      filenames '*.???'
+      filenames '*.tap'
 
       mimetypes 'text/x-tap', 'application/x-tap'
 
@@ -13,6 +14,76 @@ module Rouge
       end
 
       state :root do
+        # A TAP version may be specified.
+        rule /^TAP version \d+\n/, Name::Namespace
+
+        # Specify a plan with a plan line.
+        rule /^1\.\.\d+/, Keyword::Declaration, :plan
+
+        # A test failure
+        rule /^(not ok)([^\S\n]*)(\d*)/ do
+          groups Generic::Error, Text, Literal::Number::Integer
+          push :test
+        end
+
+        # A test success
+        rule /^(ok)([^\S\n]*)(\d*)/ do
+          groups Keyword::Reserved, Text, Literal::Number::Integer
+          push :test
+        end
+
+        # Diagnostics start with a hash.
+        rule /^#.*\n/, Comment
+
+        # TAP's version of an abort statement.
+        rule /^Bail out!.*\n/, Generic::Error
+
+        # # TAP ignores any unrecognized lines.
+        rule /^.*\n/, Text
+      end
+
+      state :plan do
+        # Consume whitespace (but not newline).
+        rule /[^\S\n]+/, Text
+
+        # A plan may have a directive with it.
+        rule /#/, Comment, :directive
+
+        # Or it could just end.
+        rule /\n/, Comment, :pop!
+
+        # Anything else is wrong.
+        rule /.*\n/, Generic::Error, :pop!
+      end
+
+      state :test do
+        # Consume whitespace (but not newline).
+        rule /[^\S\n]+/, Text
+
+        # A test may have a directive with it.
+        rule /#/, Comment, :directive
+
+        rule /\S+/, Text
+
+        rule /\n/, Text, :pop!
+      end
+
+      state :directive do
+        # Consume whitespace (but not newline).
+        rule /[^\S\n]+/, Comment
+
+        # Extract todo items.
+        rule /(?i)\bTODO\b/, Comment::Preproc
+
+        # Extract skip items.
+        rule /(?i)\bSKIP\S*/, Comment::Preproc
+
+        rule /\S+/, Comment
+
+        rule /\n/ do
+          token Comment
+          pop! 2
+        end
       end
     end
   end

--- a/lib/rouge/lexers/tap.rb
+++ b/lib/rouge/lexers/tap.rb
@@ -1,0 +1,20 @@
+module Rouge
+  module Lexers
+    class Tap < RegexLexer
+      desc 'tap'
+      tag 'tap'
+      aliases 'tap'
+      filenames '*.???'
+
+      mimetypes 'text/x-tap', 'application/x-tap'
+
+      def self.analyze_text(text)
+        return 0
+      end
+
+      state :root do
+      end
+    end
+  end
+end
+

--- a/spec/lexers/tap_spec.rb
+++ b/spec/lexers/tap_spec.rb
@@ -5,16 +5,12 @@ describe Rouge::Lexers::Tap do
     include Support::Guessing
 
     it 'guesses by filename' do
-      assert_guess :filename => 'foo.???'
+      assert_guess :filename => 'foo.tap'
     end
 
     it 'guesses by mimetype' do
       assert_guess :mimetype => 'text/x-tap'
       assert_guess :mimetype => 'application/x-tap'
-    end
-
-    it 'guesses by source' do
-      assert_guess :source => '????'
     end
   end
 end

--- a/spec/lexers/tap_spec.rb
+++ b/spec/lexers/tap_spec.rb
@@ -1,0 +1,21 @@
+describe Rouge::Lexers::Tap do
+  let(:subject) { Rouge::Lexers::Tap.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.???'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-tap'
+      assert_guess :mimetype => 'application/x-tap'
+    end
+
+    it 'guesses by source' do
+      assert_guess :source => '????'
+    end
+  end
+end
+

--- a/spec/visual/samples/tap
+++ b/spec/visual/samples/tap
@@ -1,0 +1,37 @@
+TAP version 13
+1..42
+1..13 A plan only supports directives so this text is wrong.
+ok 1 A normal test line includes a number.
+ok But a test line may also omit a number.
+
+A random line that does not look like a test or diagnostic should be ignored.
+      No matter how it is spaced out.
+
+Or if it is a totally blank line.
+
+not ok 3 This is a failing test line.
+
+# Diagnostics are any lines...
+# ... beginning with a hash character.
+
+not ok 4 There are a couple of directives. # TODO is one of those directives.
+not ok 5 # TODO: is invalid because the directive must be followed by a space.
+ok 6 - Another directive line # toDO is not case sensitive.
+
+ok 7 A line that is a # SKIP
+ok 8 Tests can be # skipped as long as the directive has the "skip" stem.
+ok 9 The TODO directive must be followed by a space, but # skip: is valid.
+1..0 # Skipped directives can show on a plan line too.
+
+Bail out! is a special phrase emitted when a TAP file aborted.
+
+not ok 10 Having TAP version 13 in the middle of a line is not a TAP version.
+not ok 11 Having Bail out! in the middle of a line is not a bail out.
+
+ok 12 Here is an empty directive. #
+
+# The most basic valid test lines.
+ok
+not ok
+
+ok 15 Only the test number should look different. Not another 42, for example.


### PR DESCRIPTION
This branch adds a lexer for the Test Anything Protocol (http://testanything.org/).

I want to say thank you. This feature was a lot of fun to work on because the Rouge project made it simple to get going. I found the README to be very approachable and the documentation clear. Thanks for letting me focus on the task (adding a lexer) rather than fiddling with tons of initial configuration. You rock! :metal:

The only hiccup I encountered was the incantation to make the `lex` generator task work. As someone who is not a regular Rubyist, it took me a little while to determine that `rake lex\[tap\]` was how I could provide the `:language` argument to that task. 