### PR TITLE
Praat: Simplified rules. Comma-list no longer recursive. Closes #334

### DIFF
--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -62,25 +62,26 @@ module Rouge
         BarkFilter BarkSpectrogram CCA Categories Cepstrogram Cepstrum
         Cepstrumc ChebyshevSeries ClassificationTable Cochleagram Collection
         ComplexSpectrogram Configuration Confusion ContingencyTable Corpus
-        Correlation Covariance CrossCorrelationTable CrossCorrelationTables DTW
-        DataModeler Diagonalizer Discriminant Dissimilarity Distance
-        Distributions DurationTier EEG ERP ERPTier EditCostsTable
-        EditDistanceTable Eigen Excitation Excitations ExperimentMFC FFNet
-        FeatureWeights FileInMemory FilesInMemory Formant FormantFilter
-        FormantGrid FormantModeler FormantPoint FormantTier GaussianMixture HMM
-        HMM_Observation HMM_ObservationSequence HMM_State HMM_StateSequence
-        Harmonicity ISpline Index Intensity IntensityTier IntervalTier KNN
-        KlattGrid KlattTable LFCC LPC Label LegendreSeries LinearRegression
-        LogisticRegression LongSound Ltas MFCC MSpline ManPages Manipulation
-        Matrix MelFilter MelSpectrogram MixingMatrix Movie Network OTGrammar
-        OTHistory OTMulti PCA PairDistribution ParamCurve Pattern Permutation
-        Photo Pitch PitchModeler PitchTier PointProcess Polygon Polynomial
-        PowerCepstrogram PowerCepstrum Procrustes RealPoint RealTier ResultsMFC
-        Roots SPINET SSCP SVD Salience ScalarProduct Similarity SimpleString
-        SortedSetOfString Sound Speaker Spectrogram Spectrum SpectrumTier
-        SpeechSynthesizer SpellingChecker Strings StringsIndex Table
-        TableOfReal TextGrid TextInterval TextPoint TextTier Tier Transition
-        VocalTract VocalTractTier Weight WordList
+        Correlation Covariance CrossCorrelationTable CrossCorrelationTableList
+        CrossCorrelationTables DTW DataModeler Diagonalizer Discriminant
+        Dissimilarity Distance Distributions DurationTier EEG ERP ERPTier
+        EditCostsTable EditDistanceTable Eigen Excitation Excitations
+        ExperimentMFC FFNet FeatureWeights FileInMemory FilesInMemory Formant
+        FormantFilter FormantGrid FormantModeler FormantPoint FormantTier
+        GaussianMixture HMM HMM_Observation HMM_ObservationSequence HMM_State
+        HMM_StateSequence HMMObservation HMMObservationSequence HMMState
+        HMMStateSequence Harmonicity ISpline Index Intensity IntensityTier
+        IntervalTier KNN KlattGrid KlattTable LFCC LPC Label LegendreSeries
+        LinearRegression LogisticRegression LongSound Ltas MFCC MSpline ManPages
+        Manipulation Matrix MelFilter MelSpectrogram MixingMatrix Movie Network
+        OTGrammar OTHistory OTMulti PCA PairDistribution ParamCurve Pattern
+        Permutation Photo Pitch PitchModeler PitchTier PointProcess Polygon
+        Polynomial PowerCepstrogram PowerCepstrum Procrustes RealPoint RealTier
+        ResultsMFC Roots SPINET SSCP SVD Salience ScalarProduct Similarity
+        SimpleString SortedSetOfString Sound Speaker Spectrogram Spectrum
+        SpectrumTier SpeechSynthesizer SpellingChecker Strings StringsIndex
+        Table TableOfReal TextGrid TextInterval TextPoint TextTier Tier
+        Transition VocalTract VocalTractTier Weight WordList
       )
 
       variables_numeric = %w(

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -257,7 +257,7 @@ module Rouge
         mixin :number
 
         rule /\b(?:#{variables_string.join('|')})\$/,  Name::Builtin
-        rule /\b(?:#{variables_numeric.join('|')})\b/, Name::Builtin
+        rule /\b(?:#{variables_numeric.join('|')})(?!\$)\b/, Name::Builtin
 
         rule /\b(Object|#{objects.join('|')})_\w+/, Name::Builtin, :object_attributes
 

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -85,7 +85,8 @@ module Rouge
       )
 
       variables_numeric = %w(
-        macintosh windows unix praatVersion pi e undefined
+        all average e left macintosh mono pi praatVersion right stereo
+        undefined unix windows
       )
 
       variables_string = %w(

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -39,7 +39,7 @@ module Rouge
         endSendPraat endsWith erb erbToHertz erf erfc exitScript exp
         extractNumber fileReadable fisherP fisherQ floor gaussP gaussQ
         hertzToBark hertzToErb hertzToMel hertzToSemitones imax imin
-        incompleteBeta incompleteGammaP index index_regex invBinomialP
+        incompleteBeta incompleteGammaP index index_regex integer invBinomialP
         invBinomialQ invChiSquareQ invFisherQ invGaussQ invSigmoid invStudentQ
         length ln lnBeta lnGamma log10 log2 max melToHertz min minusObject
         natural number numberOfColumns numberOfRows numberOfSelected
@@ -47,10 +47,10 @@ module Rouge
         phonToDifferenceLimens plusObject positive randomBinomial randomGauss
         randomInteger randomPoisson randomUniform real readFile removeObject
         rindex rindex_regex round runScript runSystem runSystem_nocheck
-        selectObject selected semitonesToHertz sentencetext sigmoid sin sinc
-        sincpi sinh soundPressureToPhon sqrt startsWith studentP studentQ tan
-        tanh variableExists word writeFile writeFileLine writeInfo
-        writeInfoLine
+        selectObject selected semitonesToHertz sentence sentencetext sigmoid
+        sin sinc sincpi sinh soundPressureToPhon sqrt startsWith studentP
+        studentQ tan tanh text variableExists word writeFile writeFileLine
+        writeInfo writeInfoLine
       )
 
       functions_array = %w(

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -307,11 +307,6 @@ module Rouge
 
         rule /(option|button)([ \t]+)/ do
           groups Keyword, Text
-          push :number
-        end
-
-        rule /(option|button)([ \t]+)/ do
-          groups Keyword, Text
           push :string_unquoted
         end
 

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -271,8 +271,8 @@ module Rouge
 
       state :operator do
         # This rule incorrectly matches === or +++++, which are not operators
-        rule /([+\/*<>=!-]=?|[&*|][&*|]?|\^|<>)/, Operator
-        rule /\b(and|or|not|div|mod)\b/,          Operator::Word
+        rule /([+\/*<>=!-]=?|[&*|][&*|]?|\^|<>)/,       Operator
+        rule /(?<![\w.])(and|or|not|div|mod)(?![\w.])/, Operator::Word
       end
 
       state :string_interpolated do

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -109,6 +109,7 @@ module Rouge
 
         mixin :function_call
 
+        rule /\b(?:select all)\b/, Keyword
         rule /\b(?:#{keywords.join('|')})\b/, Keyword
 
         rule /(\bform\b)(\s+)([^\n]+)/ do

--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -19,6 +19,25 @@ form Highlighter test
   natural Nat 4
 endform
 
+beginPause: "Highlighter test"
+  sentence: "Blank", ""
+  sentence: "My sentence", "This should all be a string"
+  text: "My text", "This should also all be a string"
+  word: "My word", "Only the first word is a string, the rest is discarded"
+  boolean: "Binary", 1
+  comment: "This should be a string"
+  optionMenu: "Drop-down", 1
+    option: "Foo"
+    option: "100"
+  choice: "Choice", 1
+    option: "Foo"
+    option: "100"
+  real: "left Range", -123.6
+  positive: "right Range max", 3.3
+  integer: "Int", 4
+  natural: "Nat", 4
+button = endPause("Cancel", "OK", 1, 2)
+
 # Periods do not establish boundaries for keywords
 form.var = 10
 # Or operators

--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -7,9 +7,11 @@ form Highlighter test
   boolean Text no
   boolean Quoted "yes"
   comment This should be a string
-  optionmenu Choice: 1
+  optionmenu Drop-down: 1
     option Foo
-    option Bar
+    option 100
+  choice Radio: 1
+    option Foo
     option 100
   real left_Range -123.6
   positive right_Range_max 3.3

--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -51,8 +51,7 @@ execute /path/to/file
 
 # Predefined variables
 a  = praatVersion
-a  = e
-a  = pi
+a  = e + pi * ( all+right) / left mod average + (mono - stereo)
 a$ = homeDirectory$ + tab$ + newline$
 a$ = temporaryDirectory$
 a$ = praatVersion$
@@ -61,6 +60,9 @@ a$ = homeDirectory$
 a$ = preferencesDirectory$
 a$ = defaultDirectory$
 nocheck selectObject: undefined
+# Not predefined variables
+a$ = e$
+a$ = pi$
 
 # Arrays are not comments
 a# = zero# (5, 6)
@@ -98,6 +100,12 @@ value$ = Table_'table'$[25, "f0"]
 fixed  = Sound_10.xmin
 fixed  = Object_foo.xmin
 fixed  = Procrustes_foo.nx
+var["vaa"] = 1 ; Hash
+
+# Special two-word keyword
+select all
+# Keyword with a predefined variable
+select  all
 
 # old-style procedure call
 call oldStyle "quoted" 2 unquoted string

--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -82,7 +82,7 @@ var = if macintosh = 1 then 0 else 1 fi ; This is an inline comment
 n = numberOfSelected("Sound")
 for i from newStyle.local to n
   name = selected$(extractWord$(selected$(), " "))
-  sound'i' = selected("Sound", i)
+  sound'i' = selected("Sound", i+(a*b))
   sound[i] = sound'i'
 endfor
 
@@ -129,12 +129,12 @@ for i from 1 to n
 
   # New-style multi-line command call with broken strings
   table = Create Table with column names: "table", 0,
-    ..."file subject speaker 
+    ..."file subject speaker
     ...f0 f1 f2 f3 " +
     ..."duration response"
 
   # Function call with trailing space
-  removeObject: pitch, table 
+  removeObject: pitch, table
 
   # Picture window commands
   selectObject: sound
@@ -242,3 +242,5 @@ endproc
 asserterror Unknown symbol:'newline$'« _
 assert '_new_style.local'
 
+@proc: a, selected("string"), b
+# Error

--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -132,7 +132,7 @@ endfor
 
 i = 1
 while i < n
-  i++
+  i += 1
   # Different styles of object selection
   select sound'i'
   sound = selected()

--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -182,7 +182,7 @@ while i < n
     ..."duration response"
 
   # Function call with trailing space
-  removeObject: pitch, table
+  removeObject: pitch, table 
 
   # Picture window commands
   selectObject: sound

--- a/spec/visual/samples/praat~
+++ b/spec/visual/samples/praat~
@@ -2,7 +2,7 @@ form Highlighter test
   sentence Blank
   sentence My_sentence This should all be a string
   text My_text This should also all be a string
-  word My_word Only the first word is a string, the rest is discarded
+  word My_word Only the first word is a string, the rest is invalid
   boolean Binary 1
   boolean Text no
   boolean Quoted "yes"
@@ -16,12 +16,6 @@ form Highlighter test
   integer Int 4
   natural Nat 4
 endform
-
-# Periods do not establish boundaries for keywords
-form.var = 10
-# Or operators
-not.an.operator$ = "Bad variable name"
-bad.or.not = 1
 
 # External scripts
 include /path/to/file
@@ -61,11 +55,6 @@ endif
 
 string$ = "Strings can be 'interpolated'"
 string$ = "But don't interpolate everything!"
-string$(10)
-
-repeat
-  string$ = string$ - right$(string$)
-until !length(string$)
 
 Text... 1 Right 0.2 Half many----hyphens
 Text... 1 Right -0.4 Bottom aحبيبa
@@ -101,15 +90,13 @@ for i from newStyle.local to n
   sound[i] = sound'i'
 endfor
 
-i = 1
-while i < n
-  i++
+for i from 1 to n
   # Different styles of object selection
   select sound'i'
   sound = selected()
   sound$ = selected$("Sound")
   select Sound 'sound$'
-  selectObject( sound[i])
+  selectObject(sound[i])
   selectObject: sound
 
   # Pause commands
@@ -140,8 +127,6 @@ while i < n
   # Multi-line command with modifier
   pitch = noprogress To Pitch (ac): 0, 75, 15, "no",
     ...0.03, 0.45, 0.01, 0.35, 0.14, 600
-  # Formulas are strings
-  Formula: "if col = 1 then row * Object_'pitch'.dx + 'first' else self fi"
 
   # do-style command with assignment
   minimum = do("Get minimum...", 0, 0, "Hertz", "Parabolic")
@@ -149,7 +134,7 @@ while i < n
   # New-style multi-line command call with broken strings
   table = Create Table with column names: "table", 0,
     ..."file subject speaker
-    ... f0 f1 f2 f" + string$(3) + " " +
+    ...f0 f1 f2 f3 " +
     ..."duration response"
 
   # Function call with trailing space
@@ -174,7 +159,7 @@ while i < n
   demoWaitForInput ( )
   demo Erase all
   demo Text: 50, "centre", 50, "half", "Finished"
-endwhile
+endfor
 
 switch$ = if switch == 1 then "a" else
   ...     if switch == 2 then "b" else
@@ -225,11 +210,6 @@ assert  a !=  b  &&  c
 assert  a <>  b  ||  c
 assert  a <   b  |   c
 assert  a >   b
-
-assert (a)or (b)
-assert (a) or(b)
-assert (a)and(b)
-
 assert "hello" =  "he" + "llo"
 assert "hello" == "hello world" - " world"
 
@@ -267,16 +247,4 @@ asserterror Unknown symbol:'newline$'« _
 assert '_new_style.local'
 
 @proc: a, selected("string"), b
-# Comment
-
-for i to saveSelection.n
-  selectObject: saveSelection.id[i]
-  appendInfoLine: selected$()
-endfor
-
-@ok(if selected$("Sound") = "tone" then 1 else 0 fi,
-  ... "selected sound is tone")
-
-@ok_formula("selected$(""Sound"") = ""tone""", "selected sound is tone")
-
-
+# Error


### PR DESCRIPTION
Simplified rules and expanded visual spec to include some new errors found.

Including:

```praat
@procedure: a, selected("string"), b
```

and

```praat
selected("Sound", i+(a*b))
```
