### PR TITLE
fix typo in prepend sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ class MyLexer < OtherLexer
   state :your_state do ... end
 
   # prepend rules to states
-  prepand :parent_state do ... end
+  prepend :parent_state do ... end
 
   # append rules to states
   append :parent_state do ... end


### PR DESCRIPTION
This fixes a small typo in the prepend documentation sample 