### PR TITLE
rougify should treat file input as utf8

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -23,7 +23,7 @@ module Rouge
 
     def read
       @read ||= begin
-        file.read
+        File.read(file, encoding: 'utf-8') 
       rescue => e
         $stderr.puts "unable to open #{input}: #{e.message}"
         exit 1


### PR DESCRIPTION
I had apparently an utf-8 issue where the rougify (cli) did not treat a file as utf8 on windows (even though it was saved as utf8 according to several editors.. sigh).

In #149 it was mentioned to correct the File.read calls to use encoding, but due to slightly different code in cli.rb I suspect that that specific instance might have been overlooked.