### PR TITLE
Add Jsonnet lexer

### DIFF
--- a/lib/rouge/demos/jsonnet
+++ b/lib/rouge/demos/jsonnet
@@ -1,0 +1,28 @@
+// Compiler template
+local CCompiler = {
+  cFlags: [],
+  out: "a.out",
+  local flags_str = std.join(" ", self.cFlags),
+  local files_str = std.join(" ", self.files),
+  cmd: "%s %s %s -o %s" % [self.compiler, flags_str, files_str, self.out],
+};
+
+// GCC specialization
+local Gcc = CCompiler { compiler: "gcc" };
+
+// Another specialization
+local Clang = CCompiler { compiler: "clang" };
+
+// Mixins - append flags
+local Opt = { cFlags: super.cFlags + ["-O3", "-DNDEBUG"] };
+local Dbg = { cFlags: super.cFlags + ["-g"] };
+
+// Output:
+{
+  targets: [
+    Gcc { files: ["a.c", "b.c"] },
+    Clang { files: ["test.c"], out: "test" },
+    Clang + Opt { files: ["test2.c"], out: "test2" },
+    Gcc + Opt + Dbg { files: ["foo.c", "bar.c"], out: "baz" },
+  ]
+}

--- a/lib/rouge/lexers/jsonnet.rb
+++ b/lib/rouge/lexers/jsonnet.rb
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class Jsonnet < RegexLexer
+      title 'Jsonnet'
+      desc 'An elegant, formally-specified config language for JSON'
+      tag 'jsonnet'
+      filenames '*.jsonnet'
+      mimetypes 'text/x-jsonnet'
+
+      def self.keywords
+        @keywords ||= Set.new %w(
+          self super local for in if then else import importstr error
+          tailstrict assert
+        )
+      end
+
+      def self.declarations
+        @declarations ||= Set.new %w(
+          function
+        )
+      end
+
+      def self.constants
+        @constants ||= Set.new %w(
+          null true false
+        )
+      end
+
+      def self.builtins
+        @builtins ||= Set.new %w(
+          acos
+          asin
+          atan
+          ceil
+          char
+          codepoint
+          cos
+          exp
+          exponent
+          filter
+          floor
+          force
+          length
+          log
+          makeArray
+          mantissa
+          objectFields
+          objectHas
+          pow
+          sin
+          sqrt
+          tan
+          thisFile
+          type
+          abs
+          assertEqual
+          escapeStringBash
+          escapeStringDollars
+          escapeStringJson
+          escapeStringPython
+          filterMap
+          flattenArrays
+          foldl
+          foldr
+          format
+          join
+          lines
+          manifestIni
+          manifestPython
+          manifestPythonVars
+          map
+          max
+          min
+          mod
+          range
+          set
+          setDiff
+          setInter
+          setMember
+          setUnion
+          sort
+          split
+          stringChars
+          substr
+          toString
+          uniq
+        )
+      end
+
+      identifier = /[a-zA-Z_][a-zA-Z0-9_]*/
+
+      state :root do
+        rule /\s+/, Text
+        rule %r(//.*?$), Comment::Single
+        rule %r(#.*?$), Comment::Single
+        rule %r(/\*.*?\*/)m, Comment::Multiline
+
+        rule /-?(?:0|[1-9]\d*)\.\d+(?:e[+-]\d+)?/i, Num::Float
+        rule /-?(?:0|[1-9]\d*)(?:e[+-]\d+)?/i, Num::Integer
+
+        rule /[{}:\.,;+\[\]=%\(\)]/, Punctuation
+
+        rule /"/, Str, :string_double
+        rule /'/, Str, :string_single
+        rule /\|\|\|/, Str, :string_block
+
+        rule /\$/, Keyword
+
+        rule identifier do |m|
+          if self.class.keywords.include? m[0]
+            token Keyword
+          elsif self.class.declarations.include? m[0]
+            token Keyword::Declaration
+          elsif self.class.constants.include? m[0]
+            token Keyword::Constant
+          elsif self.class.builtins.include? m[0]
+            token Name::Builtin
+          else
+            token Name::Other
+          end
+        end
+      end
+
+      state :string do
+        rule /\\([\\\/bfnrt]|(u[0-9a-fA-F]{4}))/, Str::Escape
+      end
+
+      state :string_double do
+        mixin :string
+        rule /\\"/, Str::Escape
+        rule /"/, Str, :pop!
+        rule /[^\\"]+/, Str
+      end
+
+      state :string_single do
+        mixin :string
+        rule /\\'/, Str::Escape
+        rule /'/, Str, :pop!
+        rule /[^\\']+/, Str
+      end
+
+      state :string_block do
+        mixin :string
+        rule /\|\|\|/, Str, :pop!
+        rule /.*/, Str
+      end
+    end
+  end
+end

--- a/spec/lexers/jsonnet_spec.rb
+++ b/spec/lexers/jsonnet_spec.rb
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Jsonnet do
+  let(:subject) { Rouge::Lexers::Jsonnet.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.jsonnet'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-jsonnet'
+    end
+  end
+end

--- a/spec/visual/samples/jsonnet
+++ b/spec/visual/samples/jsonnet
@@ -1,0 +1,62 @@
+/*
+Here is a multi-line comment.
+*/
+
+local foo = import "bar/baz.jsonnet";
+
+// Single line comment.
+local CCompiler = {
+  cFlags: [],
+  out: "a.out",
+  local flags_str = std.join(" ", self.cFlags),
+  local files_str = std.join(" ", self.files),
+  cmd: "%s %s %s -o %s" % [self.compiler, flags_str, files_str, self.out],
+};
+
+// Compiler specializations
+local Gcc = CCompiler { compiler: "gcc" };
+local Clang = CCompiler { compiler: "clang" };
+
+// Mixins - append flags
+local Opt = {
+  cFlags: super.cFlags + ["-O3", "-DNDEBUG"]
+};
+local Dbg = {
+  cflags: super.cFlags + ["-g"]
+};
+
+local script = |||
+  #!/bin/bash
+  if [ $# -lt 1 ]; then
+    echo "No arguments!"
+  else
+    echo "$# arguments!"
+  fi
+|||;
+
+{
+  targets: [
+    Gcc {
+      files: ["a.c", "b.c"]
+    },
+    Clang {
+      files: ["test.c"],
+      out: "test"
+    },
+    Clang + Opt {
+      files: ['test2.c'], out: "test2"
+    }
+    Gcc + Opt + Dbg { files: ["foo.c", "bar.c"], out: "baz" },
+  ],
+  values: {
+    string: "newline \n tab quote\" \tunicode\u0af4",
+    integer: 12,
+    negativeInteger: -12,
+    integerExponent: 12e+4,
+    float: 0.04,
+    floatExponent: 4.0e-2,
+    boolean: true,
+    nullValue: null,
+    targets: $.targets,
+  }
+}


### PR DESCRIPTION
This PR adds a lexer for Google's [Jsonnet](http://jsonnet.org). Jsonnet is a lazily-evaluated, tuple-based configuration generation language that compiles to JSON.

Fixes #391 
