### PR TITLE
Add highlight_numbers and anchors options to html formatter

### DIFF
--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -103,10 +103,12 @@ module Rouge
         if @highlight_lines
           formatted_lines = formatted.split("\n")
           formatted = formatted_lines.each_with_index.map { |str, i|
-            @highlight_lines.include?(i+1) ? "<span class=\"hll\">#{str}\n</span>" : "#{str}"
+            @highlight_lines.include?(i+1) ? "<span class=\"hll\">#{str}\n</span>" : "#{str}\n"
           }.join("")
 
           numbers = numbers.map { |a| @highlight_lines.include?(a) ? "<span class=\"hll\">#{a}\n</span>" : "#{a}\n" }.join("")
+        else
+          numbers = numbers.join("\n")
         end
 
         # generate a string of newline-separated line numbers for the gutter>


### PR DESCRIPTION
This PR adds `highlight_lines` feature for html formatter.
Also there is `anchors` option that similar to `lineanchors` option in pygments.

I'm not familiar with ruby, so it's maybe a bit ugly. Also have no experience with ruby tests, so there is no specs for this features.

Fixes #264