### PR TITLE
Add *.cljc filename mask to clojure lexer

### DIFF
--- a/lib/rouge/lexers/clojure.rb
+++ b/lib/rouge/lexers/clojure.rb
@@ -9,7 +9,7 @@ module Rouge
       tag 'clojure'
       aliases 'clj', 'cljs'
 
-      filenames '*.clj', '*.cljs'
+      filenames '*.clj', '*.cljs', '*.cljc'
 
       mimetypes 'text/x-clojure', 'application/x-clojure'
 


### PR DESCRIPTION
Since Clojure 1.7 *.cljc files are used for code that is shared between Clojure and ClojureScript