### PR TITLE
Add literal dictionary support for Objective C

### DIFF
--- a/lib/rouge/demos/objective_c
+++ b/lib/rouge/demos/objective_c
@@ -12,3 +12,7 @@
 @end
 
 NSArray *arrayLiteral = @[@"abc", @1];
+NSDictionary *dictLiteral = @{
+  @"hello": @"world",
+  @"goodbye": @"cruel world"
+};

--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -80,6 +80,7 @@ module Rouge
         rule /[?]/, Punctuation, :ternary
         rule /\[/,  Punctuation, :message
         rule /@\[/, Punctuation, :array_literal
+        rule /@\{/, Punctuation, :dictionary_literal
       end
 
       state :ternary do
@@ -118,6 +119,12 @@ module Rouge
 
       state :array_literal do
         rule /]/, Punctuation, :pop!
+        rule /,/, Punctuation
+        mixin :statements
+      end
+
+      state :dictionary_literal do
+        rule /}/, Punctuation, :pop!
         rule /,/, Punctuation
         mixin :statements
       end

--- a/spec/visual/samples/objective_c
+++ b/spec/visual/samples/objective_c
@@ -38,6 +38,14 @@ for (key in dictionary) {
     NSLog(@"English: %@, Latin: %@", key, [dictionary valueForKey:key]);
 }
 
+NSDictionary *literalDict = @{
+    @"name" : NSUserName(),
+    @"date" : [NSDate date],
+    @"processInfo" : [NSProcessInfo processInfo]
+};
+
+NSArray *literalArray = @[ @"Hello", NSApp, [NSNumber numberWithInt:42] ];
+
 // MyClass.h
 @import Foundation;
 


### PR DESCRIPTION
We use a lot of literal dictionaries in our Objective C documentation, and since the switch to rouge this produces errors. This resolves the issues, but let me know if it is the wrong approach. Thanks so much!