### PR TITLE
Fix parsing of inline blocks inside messages with arguments

### DIFF
--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -109,6 +109,7 @@ module Rouge
       end
 
       state :message_with_args do
+        rule /\{/, Punctuation, :function
         rule /(#{id})(\s*)(:)/ do
           groups(Name::Function, Text, Punctuation)
         end

--- a/spec/visual/samples/objective_c
+++ b/spec/visual/samples/objective_c
@@ -29,6 +29,19 @@
 
 @end
 
+double (^multiplyTwoValues)(double, double) = ^(double firstValue, double secondValue) {
+    return firstValue * secondValue;
+};
+
+void (^simpleBlock)(void) = ^{
+    NSLog(@"This is a block");
+};
+
+[[SomeClass] inlineBlock:(^NSString *){
+    NSString *var = @"blah";
+    return var;
+}];
+
 NSDictionary *dictionary = [NSDictionary dictionaryWithObjectsAndKeys:
     @"quattuor", @"four", @"quinque", @"five", @"sex", @"six", nil];
 


### PR DESCRIPTION
This fix prevents `;` from being rendered as an error inside inline block arguments. I'm not totally sure if `:function` is the best state to use for this, but it seems to work. Please let me know if there is a more correct solution. Thanks!