### PR TITLE
Add support for OpenCL C

### DIFF
--- a/lib/rouge/demos/opencl_c
+++ b/lib/rouge/demos/opencl_c
@@ -1,0 +1,11 @@
+// Device code
+kernel __attribute__((reqd_work_group_size(128, 1, 1)))
+kernel void process_seed(read_only image3d_t edge_weights, global int *seedmap, const int4 dimensions) {
+	size_t local_id = get_local_id(0);
+	size_t group_id = get_group_id(0);
+	global float *cache = caches + get_group_id(0) * dimensions.w;
+}
+
+// Host code
+cl_float test = 1.1f;
+cl_int4 w = {1.0, 1.0, 1.0, 0.0};

--- a/lib/rouge/lexers/opencl_c.rb
+++ b/lib/rouge/lexers/opencl_c.rb
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    load_lexer 'c.rb'
+
+    class OpenCLC < C
+      tag 'opencl_c'
+      title "OpenCL C"
+      desc 'the OpenCL C programming language used to create kernels that are executed on OpenCL devices'
+      aliases 'opencl'
+      filenames '*.cl', '*.c', '*.h'
+
+      mimetypes 'text/x-opencl_c', 'application/x-opencl_c'
+
+      def self.keywords_type
+        @keywords_type ||= Set.new %w(
+          size_t ptrdiff_t intptr_t uintptr_t void
+
+          unsigned
+          bool 
+          char cl_char uchar cl_uchar
+          short cl_short ushort cl_ushort
+          int cl_int int uint cl_uint
+          long cl_long ulong cl_ulong
+          float cl_float
+          double cl_double
+          half
+          
+          char2 char3 char4 char8 char16
+          cl_char2 cl_char3 cl_char4 cl_char8 cl_char16
+          uchar2 uchar3 uchar4 uchar8 uchar16
+          cl_uchar2 cl_uchar3 cl_uchar4 cl_uchar8 cl_uchar16
+          short2 short3 short4 short8 short16
+          cl_short2 cl_short3 cl_short4 cl_short8 cl_short16
+          ushort2 ushort3 ushort4 ushort8 ushort16
+          cl_ushort2 cl_ushort3 cl_ushort4 cl_ushort8 cl_ushort16
+          int2 int3 int4 int8 int16
+          cl_int2 cl_int3 cl_int4 cl_int8 cl_int16
+          uint2 uint3 uint4 uint8 uint16
+          cl_uint2 cl_uint3 cl_uint4 cl_uint8 cl_uint16
+          long2 long3 long4 long8 long16
+          cl_long2 cl_long3 cl_long4 cl_long8 cl_long16
+          ulong2 ulong3 ulong4 ulong8 ulong16
+          cl_ulong2 cl_ulong3 cl_ulong4 cl_ulong8 cl_ulong16
+          float2 float3 float4 float8 float16
+          cl_float2 cl_float3 cl_float4 cl_float8 cl_float16
+          double2 double3 double4 double8 double16
+          
+          image2d_t
+          image3d_t
+          image2d_array_t
+          image1d_t
+          image1d_buffer_t
+          image1d_array_t
+          image2d_depth_t
+          image2d_array_depth_t
+          sampler_t
+          queue_t
+          ndrange_t
+          clk_event_t
+          reserve_id_t
+          event_t
+          cl_mem_fence_flags
+          
+          queue_t
+          cl_command_queue
+          clk_event_t
+          cl_event
+          
+          FLT_MAX FLT_MIN
+        )
+      end
+
+      def self.keywords
+        @keywords ||= Set.new %w(
+          __global global
+          __local local
+          __constant constant
+          __private private
+          __generic generic
+          __kernel kernel
+          __read_only read_only
+          __write_only write_only
+          __read_write read_write
+          uniform pipe
+        )
+      end
+
+      def self.reserved
+        @reserved ||= Set.new %w(
+          __asm __int8 __based __except __int16 __stdcall __cdecl
+          __fastcall __int32 __declspec __finally __int61 __try __leave
+          inline _inline __inline naked _naked __naked restrict _restrict
+          __restrict thread _thread __thread typename _typename __typename
+          imaginary complex
+        )
+      end
+
+      def self.builtins
+        @builtins ||= %w(true false)
+      end
+
+      def self.analyze_text(text)
+        return 1.0 if text =~ /(cl_int|cl_device|cl_float|cl_platform)\b/
+        return 0.1
+      end
+    
+    end
+  end
+end

--- a/spec/lexers/c_spec.rb
+++ b/spec/lexers/c_spec.rb
@@ -7,7 +7,7 @@ describe Rouge::Lexers::C do
     include Support::Guessing
 
     it 'guesses by filename' do
-      assert_guess :filename => 'foo.c'
+      assert_guess :filename => 'foo.c', :source => 'foo'
       assert_guess :filename => 'foo.h', :source => 'foo'
     end
 

--- a/spec/lexers/common_lisp_spec.rb
+++ b/spec/lexers/common_lisp_spec.rb
@@ -7,7 +7,6 @@ describe Rouge::Lexers::CommonLisp do
     include Support::Guessing
 
     it 'guesses by filename' do
-      assert_guess :filename => 'foo.cl'
       assert_guess :filename => 'foo.lisp'
       assert_guess :filename => 'foo.el'
     end

--- a/spec/lexers/opencl_c_spec.rb
+++ b/spec/lexers/opencl_c_spec.rb
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::OpenCLC do
+  let(:subject) { Rouge::Lexers::OpenCLC.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.cl', :source => '@property'
+    end
+
+    it 'guesses by source' do
+      assert_guess :filename => 'foo.c', :source => 'cl_device'
+      assert_guess :filename => 'foo.h', :source => 'cl_int'
+      assert_guess :source => 'cl_float'
+    end
+  end
+end
+

--- a/spec/visual/samples/opencl_c
+++ b/spec/visual/samples/opencl_c
@@ -1,0 +1,11 @@
+// Device code
+kernel __attribute__((reqd_work_group_size(128, 1, 1)))
+kernel void process_seed(read_only image3d_t edge_weights, global int *seedmap, const int4 dimensions) {
+	size_t local_id = get_local_id(0);
+	size_t group_id = get_group_id(0);
+	global float *cache = caches + get_group_id(0) * dimensions.w;
+}
+
+// Host code
+cl_float test = 1.1f;
+cl_int4 w = {1.0, 1.0, 1.0, 0.0};


### PR DESCRIPTION
This adds support for syntax highlighting for the OpenCL C language as described in https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf.