### PR TITLE
Fix Swift multiline comment lexing with forward slashes

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -42,13 +42,23 @@ module Rouge
 
       state :inline_whitespace do
         rule /\s+/m, Text
-        rule %r((?<re>\/\*(?:(?>[^\/\*\*\/]+)|\g<re>)*\*\/))m, Comment::Multiline
+        mixin :has_comments
       end
 
       state :whitespace do
         rule /\n+/m, Text, :bol
         rule %r(\/\/.*?$), Comment::Single, :bol
         mixin :inline_whitespace
+      end
+
+      state :has_comments do
+        rule %r(/[*]), Comment::Multiline, :nested_comment
+      end
+
+      state :nested_comment do
+        mixin :has_comments
+        rule %r([*]/), Comment::Multiline, :pop!
+        rule /./m, Comment::Multiline
       end
 
       state :root do

--- a/spec/lexers/swift_spec.rb
+++ b/spec/lexers/swift_spec.rb
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Swift do
+  let(:subject) { Rouge::Lexers::Swift.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.swift'
+    end
+  end
+
+  describe 'lexer' do
+    include Support::Lexing
+
+    it 'lexes multiline comments with asterisks and forward slashes' do
+      multiline_comment = <<EOS.strip!
+/*
+  Multiline comment
+  with asterisks (*) and forward slashes (//)
+*/
+EOS
+
+      assert_tokens_equal multiline_comment,
+                          ['Comment.Multiline', multiline_comment]
+    end
+
+    it 'lexes nested comments as a single comment' do
+      nested_comment = <<EOS.strip!
+/*
+  /*
+    Define a and b constants
+  */
+
+  let a = 1
+  let b = 2
+
+  /*
+    Define c and d constants
+  */
+
+  let c = 3
+  let d = 4
+*/
+EOS
+
+      separate_comment = <<EOS.strip!
+/*
+  A separate comment
+*/
+EOS
+      combined_comments = "#{nested_comment}\n\n#{separate_comment}"
+
+      assert_tokens_equal combined_comments,
+                          ['Comment.Multiline', nested_comment],
+                          ['Text', "\n\n"],
+                          ['Comment.Multiline', separate_comment]
+    end
+  end
+end


### PR DESCRIPTION
Fixes #453 

Change the regex to fix/add support for nested comments, since Swift supports it. Also, ensures that forward slashes within a comment (such as in a URL) don't cause issues. Thanks to @DouweM for the Regex help. This also adds some simple Swift tests \o/