### PR TITLE
Update license in gemspec to MIT, 2-clause BSD

### DIFF
--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "rouge"
   s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'lib/**/*.yml', 'bin/rougify', 'lib/rouge/demos/*']
   s.executables = %w(rougify)
-  s.license = 'MIT (see LICENSE file)'
+  s.license = 'MIT, 2-clause BSD'
 end


### PR DESCRIPTION
This is more correct and easier to audit by license auto-detectors.