### PR TITLE
Support groovy triple quotes, and use more robust regexes

### DIFF
--- a/lib/rouge/lexers/groovy.rb
+++ b/lib/rouge/lexers/groovy.rb
@@ -61,10 +61,10 @@ module Rouge
         rule /""".*?"""/m, Str::Double
         rule /'''.*?'''/m, Str::Single
 
-        rule /"(\\\\|\\"|[^"])*"/, Str::Double
-        rule /'(\\\\|\\'|[^'])*'/, Str::Single
-        rule %r(\$/((?!/\$).)*/\$), Str
-        rule %r(/(\\\\|\\/|[^/])*/), Str
+        rule /"(\\.|\\\n|.)*?"/, Str::Double
+        rule /'(\\.|\\\n|.)*?'/, Str::Single
+        rule %r(\$/(\$.|.)*?/\$)m, Str
+        rule %r(/(\\.|\\\n|.)*?/), Str
         rule /'\\.'|'[^\\]'|'\\u[0-9a-f]{4}'/, Str::Char
         rule /(\.)([a-zA-Z_][a-zA-Z0-9_]*)/ do
           groups Operator, Name::Attribute

--- a/lib/rouge/lexers/groovy.rb
+++ b/lib/rouge/lexers/groovy.rb
@@ -57,10 +57,14 @@ module Rouge
         rule /package\b/, Keyword::Namespace, :import
         rule /import\b/, Keyword::Namespace, :import
 
+        # TODO: highlight backslash escapes
+        rule /""".*?"""/m, Str::Double
+        rule /'''.*?'''/m, Str::Single
+
         rule /"(\\\\|\\"|[^"])*"/, Str::Double
         rule /'(\\\\|\\'|[^'])*'/, Str::Single
         rule %r(\$/((?!/\$).)*/\$), Str
-        rule %r(/(\\\\|\\"|[^/])*/), Str
+        rule %r(/(\\\\|\\/|[^/])*/), Str
         rule /'\\.'|'[^\\]'|'\\u[0-9a-f]{4}'/, Str::Char
         rule /(\.)([a-zA-Z_][a-zA-Z0-9_]*)/ do
           groups Operator, Name::Attribute

--- a/spec/visual/samples/groovy
+++ b/spec/visual/samples/groovy
@@ -1,3 +1,17 @@
+String json = """
+  {
+    "formula": "(a+b)/2",
+    "iid": "c-1"
+  }
+"""
+
+String json = '''
+  {
+    "formula": "(a+b)/2",
+    "iid": "c-1"
+  }
+'''
+
 // This source code comes from http://www.odelia-technologies.com/node/200
 
 package com.odelia.groovy.simpleworkflow


### PR DESCRIPTION
I've removed the sketchy negative-lookahead regexes that were in the Groovy lexer, and also updated the string literals to conform to the [groovy docs](http://docs.groovy-lang.org/latest/html/documentation/index.html#_dollar_slashy_string).

In addition, we now have basic support for triple-quoted strings.