### PR TITLE
Refactor.guessers

### DIFF
--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -37,6 +37,7 @@ load load_dir.join('rouge/text_analyzer.rb')
 load load_dir.join('rouge/token.rb')
 
 load load_dir.join('rouge/guesser.rb')
+load load_dir.join('rouge/guessers/glob_mapping.rb')
 load load_dir.join('rouge/guessers/filename.rb')
 load load_dir.join('rouge/guessers/mimetype.rb')
 load load_dir.join('rouge/guessers/source.rb')

--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -36,6 +36,11 @@ load load_dir.join('rouge/util.rb')
 load load_dir.join('rouge/text_analyzer.rb')
 load load_dir.join('rouge/token.rb')
 
+load load_dir.join('rouge/guesser.rb')
+load load_dir.join('rouge/guessers/filename.rb')
+load load_dir.join('rouge/guessers/mimetype.rb')
+load load_dir.join('rouge/guessers/source.rb')
+
 load load_dir.join('rouge/lexer.rb')
 load load_dir.join('rouge/regex_lexer.rb')
 load load_dir.join('rouge/template_lexer.rb')

--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -38,6 +38,7 @@ load load_dir.join('rouge/token.rb')
 
 load load_dir.join('rouge/guesser.rb')
 load load_dir.join('rouge/guessers/glob_mapping.rb')
+load load_dir.join('rouge/guessers/modeline.rb')
 load load_dir.join('rouge/guessers/filename.rb')
 load load_dir.join('rouge/guessers/mimetype.rb')
 load load_dir.join('rouge/guessers/source.rb')

--- a/lib/rouge/guesser.rb
+++ b/lib/rouge/guesser.rb
@@ -14,6 +14,26 @@ module Rouge
       lexers.size < original_size ? lexers : []
     end
 
+    def collect_best(lexers, opts={}, &scorer)
+      best = []
+      best_score = opts[:threshold]
+
+      lexers.each do |lexer|
+        score = scorer.call(lexer)
+
+        next if score.nil?
+
+        if best_score.nil? || score > best_score
+          best_score = score
+          best = [lexer]
+        elsif score == best_score
+          best << lexer
+        end
+      end
+
+      best
+    end
+
     def filter(lexers)
       raise 'abstract'
     end

--- a/lib/rouge/guesser.rb
+++ b/lib/rouge/guesser.rb
@@ -6,7 +6,7 @@ module Rouge
       guessers.each do |g|
         new_lexers = case g
         when Guesser then g.filter(lexers)
-        when -> (x) { x.respond_to? :call } then g.call(lexers)
+        when proc { |x| x.respond_to? :call } then g.call(lexers)
         else raise "bad guesser: #{g}"
         end
 

--- a/lib/rouge/guesser.rb
+++ b/lib/rouge/guesser.rb
@@ -1,0 +1,21 @@
+module Rouge
+  class Guesser
+    def self.guess(guessers, lexers)
+      original_size = lexers.size
+
+      guessers.each do |g|
+        new_lexers = g.filter(lexers)
+        lexers = new_lexers.any? ? new_lexers : lexers
+      end
+
+      # if we haven't filtered the input at *all*,
+      # then we have no idea what language it is,
+      # so we bail and return [].
+      lexers.size < original_size ? lexers : []
+    end
+
+    def filter(lexers)
+      raise 'abstract'
+    end
+  end
+end

--- a/lib/rouge/guesser.rb
+++ b/lib/rouge/guesser.rb
@@ -4,7 +4,12 @@ module Rouge
       original_size = lexers.size
 
       guessers.each do |g|
-        new_lexers = g.filter(lexers)
+        new_lexers = case g
+        when Guesser then g.filter(lexers)
+        when -> (x) { x.respond_to? :call } then g.call(lexers)
+        else raise "bad guesser: #{g}"
+        end
+
         lexers = new_lexers.any? ? new_lexers : lexers
       end
 

--- a/lib/rouge/guesser.rb
+++ b/lib/rouge/guesser.rb
@@ -10,7 +10,7 @@ module Rouge
         else raise "bad guesser: #{g}"
         end
 
-        lexers = new_lexers.any? ? new_lexers : lexers
+        lexers = new_lexers && new_lexers.any? ? new_lexers : lexers
       end
 
       # if we haven't filtered the input at *all*,

--- a/lib/rouge/guessers/filename.rb
+++ b/lib/rouge/guessers/filename.rb
@@ -14,9 +14,7 @@ module Rouge
       # In this case, nginx will win because the pattern has no wildcards,
       # while `*.conf` has one.
       def filter(lexers)
-        out = []
-        best_seen = nil
-        lexers.each do |lexer|
+        out = collect_best(lexers) do |lexer|
           score = lexer.filenames.map do |pattern|
             if File.fnmatch?(pattern, @basename, File::FNM_DOTMATCH)
               # specificity is better the fewer wildcards there are
@@ -24,14 +22,9 @@ module Rouge
             end
           end.compact.min
 
-          next unless score
 
-          if best_seen.nil? || score < best_seen
-            best_seen = score
-            out = [lexer]
-          elsif score == best_seen
-            out << lexer
-          end
+          # use negative scores so smaller is better
+          score.nil? ? nil : -score
         end
 
         out.any? ? out : lexers

--- a/lib/rouge/guessers/filename.rb
+++ b/lib/rouge/guessers/filename.rb
@@ -18,13 +18,9 @@ module Rouge
           score = lexer.filenames.map do |pattern|
             if File.fnmatch?(pattern, @basename, File::FNM_DOTMATCH)
               # specificity is better the fewer wildcards there are
-              pattern.scan(/[*?\[]/).size
+              -pattern.scan(/[*?\[]/).size
             end
           end.compact.min
-
-
-          # use negative scores so smaller is better
-          score.nil? ? nil : -score
         end
 
         out.any? ? out : lexers

--- a/lib/rouge/guessers/filename.rb
+++ b/lib/rouge/guessers/filename.rb
@@ -1,0 +1,41 @@
+module Rouge
+  module Guessers
+    class Filename < Guesser
+      attr_reader :fname
+      def initialize(filename)
+        @filename = filename
+        @basename = File.basename(filename)
+      end
+
+      # returns a list of lexers that match the given filename with
+      # equal specificity (i.e. number of wildcards in the pattern).
+      # This helps disambiguate between, e.g. the Nginx lexer, which
+      # matches `nginx.conf`, and the Conf lexer, which matches `*.conf`.
+      # In this case, nginx will win because the pattern has no wildcards,
+      # while `*.conf` has one.
+      def filter(lexers)
+        out = []
+        best_seen = nil
+        lexers.each do |lexer|
+          score = lexer.filenames.map do |pattern|
+            if File.fnmatch?(pattern, @basename, File::FNM_DOTMATCH)
+              # specificity is better the fewer wildcards there are
+              pattern.scan(/[*?\[]/).size
+            end
+          end.compact.min
+
+          next unless score
+
+          if best_seen.nil? || score < best_seen
+            best_seen = score
+            out = [lexer]
+          elsif score == best_seen
+            out << lexer
+          end
+        end
+
+        out.any? ? out : lexers
+      end
+    end
+  end
+end

--- a/lib/rouge/guessers/filename.rb
+++ b/lib/rouge/guessers/filename.rb
@@ -14,7 +14,7 @@ module Rouge
       # In this case, nginx will win because the pattern has no wildcards,
       # while `*.conf` has one.
       def filter(lexers)
-        out = collect_best(lexers) do |lexer|
+        collect_best(lexers) do |lexer|
           score = lexer.filenames.map do |pattern|
             if File.fnmatch?(pattern, @basename, File::FNM_DOTMATCH)
               # specificity is better the fewer wildcards there are
@@ -22,8 +22,6 @@ module Rouge
             end
           end.compact.min
         end
-
-        out.any? ? out : lexers
       end
     end
   end

--- a/lib/rouge/guessers/filename.rb
+++ b/lib/rouge/guessers/filename.rb
@@ -4,7 +4,6 @@ module Rouge
       attr_reader :fname
       def initialize(filename)
         @filename = filename
-        @basename = File.basename(filename)
       end
 
       # returns a list of lexers that match the given filename with
@@ -14,14 +13,12 @@ module Rouge
       # In this case, nginx will win because the pattern has no wildcards,
       # while `*.conf` has one.
       def filter(lexers)
-        collect_best(lexers) do |lexer|
-          score = lexer.filenames.map do |pattern|
-            if File.fnmatch?(pattern, @basename, File::FNM_DOTMATCH)
-              # specificity is better the fewer wildcards there are
-              -pattern.scan(/[*?\[]/).size
-            end
-          end.compact.min
+        mapping = {}
+        lexers.each do |lexer|
+          mapping[lexer.name] = lexer.filenames || []
         end
+
+        GlobMapping.new(mapping, @filename).filter(lexers)
       end
     end
   end

--- a/lib/rouge/guessers/glob_mapping.rb
+++ b/lib/rouge/guessers/glob_mapping.rb
@@ -1,0 +1,39 @@
+module Rouge
+  module Guessers
+    # This class allows for custom behavior
+    # with glob -> lexer name mappings
+    class GlobMapping < Guesser
+      def self.by_pairs(mapping)
+        glob_map = {}
+        mapping.each do |(glob, lexer_name)|
+          lexer = Lexer.find(lexer_name)
+
+          # ignore unknown lexers and canonicalize
+          # the name
+          glob_map[lexer.name] = glob if lexer
+        end
+
+        new(glob_map)
+      end
+
+      attr_reader :glob_map, :filename
+      def initialize(glob_map, filename)
+        @glob_map = glob_map
+        @filename = filename
+      end
+
+      def filter(lexers)
+        basename = File.basename(filename)
+
+        collect_best(lexers) do |lexer|
+          score = (@glob_map[lexer.name] || []).map do |pattern|
+            if File.fnmatch?(pattern, basename, File::FNM_DOTMATCH)
+              # specificity is better the fewer wildcards there are
+              -pattern.scan(/[*?\[]/).size
+            end
+          end.compact.min
+        end
+      end
+    end
+  end
+end

--- a/lib/rouge/guessers/glob_mapping.rb
+++ b/lib/rouge/guessers/glob_mapping.rb
@@ -29,12 +29,17 @@ module Rouge
 
         collect_best(lexers) do |lexer|
           score = (@glob_map[lexer.name] || []).map do |pattern|
-            if File.fnmatch?(pattern, basename, File::FNM_DOTMATCH)
+            if test_pattern(pattern, basename)
               # specificity is better the fewer wildcards there are
               -pattern.scan(/[*?\[]/).size
             end
           end.compact.min
         end
+      end
+
+      private
+      def test_pattern(pattern, path)
+        File.fnmatch?(pattern, path, File::FNM_DOTMATCH | File::FNM_CASEFOLD)
       end
     end
   end

--- a/lib/rouge/guessers/glob_mapping.rb
+++ b/lib/rouge/guessers/glob_mapping.rb
@@ -3,17 +3,19 @@ module Rouge
     # This class allows for custom behavior
     # with glob -> lexer name mappings
     class GlobMapping < Guesser
-      def self.by_pairs(mapping)
+      def self.by_pairs(mapping, filename)
         glob_map = {}
         mapping.each do |(glob, lexer_name)|
           lexer = Lexer.find(lexer_name)
 
-          # ignore unknown lexers and canonicalize
-          # the name
-          glob_map[lexer.name] = glob if lexer
+          # ignore unknown lexers
+          next unless lexer
+
+          glob_map[lexer.name] ||= []
+          glob_map[lexer.name] << glob
         end
 
-        new(glob_map)
+        new(glob_map, filename)
       end
 
       attr_reader :glob_map, :filename

--- a/lib/rouge/guessers/mimetype.rb
+++ b/lib/rouge/guessers/mimetype.rb
@@ -1,0 +1,14 @@
+module Rouge
+  module Guessers
+    class Mimetype < Guesser
+      attr_reader :mimetype
+      def initialize(mimetype)
+        @mimetype = mimetype
+      end
+
+      def filter(lexers)
+        lexers.select { |lexer| lexer.mimetypes.include? @mimetype }
+      end
+    end
+  end
+end

--- a/lib/rouge/guessers/modeline.rb
+++ b/lib/rouge/guessers/modeline.rb
@@ -1,0 +1,42 @@
+module Rouge
+  module Guessers
+    class Modeline < Guesser
+      # [jneen] regexen stolen from linguist
+      EMACS_MODELINE = /-\*-\s*(?:(?!mode)[\w-]+\s*:\s*(?:[\w+-]+)\s*;?\s*)*(?:mode\s*:)?\s*([\w+-]+)\s*(?:;\s*(?!mode)[\w-]+\s*:\s*[\w+-]+\s*)*;?\s*-\*-/i
+
+      # First form vim modeline
+      # [text]{white}{vi:|vim:|ex:}[white]{options}
+      # ex: 'vim: syntax=ruby'
+      VIM_MODELINE_1 = /(?:vim|vi|ex):\s*(?:ft|filetype|syntax)=(\w+)\s?/i
+
+      # Second form vim modeline (compatible with some versions of Vi)
+      # [text]{white}{vi:|vim:|Vim:|ex:}[white]se[t] {options}:[text]
+      # ex: 'vim set syntax=ruby:'
+      VIM_MODELINE_2 = /(?:vim|vi|Vim|ex):\s*se(?:t)?.*\s(?:ft|filetype|syntax)=(\w+)\s?.*:/i
+
+      MODELINES = [EMACS_MODELINE, VIM_MODELINE_1, VIM_MODELINE_2]
+
+      def initialize(source, opts={})
+        @source = source
+        @lines = opts[:lines] || 5
+      end
+
+      def filter(lexers)
+        # don't bother reading the stream if we've already decided
+        return lexers if lexers.size == 1
+
+        source_text = @source
+        source_text = source_text.read if source_text.respond_to? :read
+
+        lines = source_text.split(/\r?\n/)
+
+        search_space = (lines.first(@lines) + lines.last(@lines)).join("\n")
+
+        matches = MODELINES.map { |re| re.match(search_space) }.compact
+        match_set = Set.new(matches.map { |m| m[1] })
+
+        lexers.select { |l| (Set.new([l.tag] + l.aliases) & match_set).any? }
+      end
+    end
+  end
+end

--- a/lib/rouge/guessers/source.rb
+++ b/lib/rouge/guessers/source.rb
@@ -1,0 +1,48 @@
+module Rouge
+  module Guessers
+    class Source < Guesser
+      attr_reader :source
+      def initialize(source)
+        @source = source
+      end
+
+      def filter(lexers)
+        # don't bother reading the input if
+        # we've already filtered to 1
+        return lexers if lexers.size == 1
+
+        # If we're filtering against *all* lexers, we only use confident return
+        # values from analyze_text.  But if we've filtered down already, we can trust
+        # the analysis more.
+        threshold = lexers.size < 10 ? 0 : 0.5
+
+        source_text = case @source
+        when String
+          @source
+        when ->(s){ s.respond_to? :read }
+          @source.read
+        else
+          raise 'invalid source'
+        end
+
+        Lexer.assert_utf8!(source_text)
+
+        source_text = TextAnalyzer.new(source_text)
+
+        best_result = threshold
+        best_match = nil
+        lexers.each do |lexer|
+          result = lexer.analyze_text(source_text) || 0
+          return [lexer] if result == 1
+
+          if result > best_result
+            best_match = lexer
+            best_result = result
+          end
+        end
+
+        [best_match]
+      end
+    end
+  end
+end

--- a/lib/rouge/guessers/source.rb
+++ b/lib/rouge/guessers/source.rb
@@ -29,19 +29,10 @@ module Rouge
 
         source_text = TextAnalyzer.new(source_text)
 
-        best_result = threshold
-        best_match = nil
-        lexers.each do |lexer|
-          result = lexer.analyze_text(source_text) || 0
-          return [lexer] if result == 1
-
-          if result > best_result
-            best_match = lexer
-            best_result = result
-          end
+        collect_best(lexers, threshold: threshold) do |lexer|
+          next unless lexer.methods(false).include? :analyze_text
+          lexer.analyze_text(source_text)
         end
-
-        [best_match]
       end
     end
   end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -109,12 +109,12 @@ module Rouge
       # to use.
       def guesses(info={})
         mimetype, filename, source = info.values_at(:mimetype, :filename, :source)
+        custom_globs = info[:custom_globs]
 
-        guessers = info[:guessers] || []
-
-        guessers = []
+        guessers = (info[:guessers] || []).dup
 
         guessers << Guessers::Mimetype.new(mimetype) if mimetype
+        guessers << Guessers::GlobMapping.by_pairs(custom_globs, filename) if custom_globs && filename
         guessers << Guessers::Filename.new(filename) if filename
         guessers << Guessers::Source.new(source) if source
 

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -119,7 +119,7 @@ module Rouge
         guessers << Guessers::Modeline.new(source) if source
         guessers << Guessers::Source.new(source) if source
 
-        Guesser.guess(guessers, registry.values.uniq)
+        Guesser.guess(guessers, Lexer.all)
       end
 
       class AmbiguousGuess < StandardError

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -116,6 +116,7 @@ module Rouge
         guessers << Guessers::Mimetype.new(mimetype) if mimetype
         guessers << Guessers::GlobMapping.by_pairs(custom_globs, filename) if custom_globs && filename
         guessers << Guessers::Filename.new(filename) if filename
+        guessers << Guessers::Modeline.new(source) if source
         guessers << Guessers::Source.new(source) if source
 
         Guesser.guess(guessers, registry.values.uniq)

--- a/lib/rouge/lexers/http.rb
+++ b/lib/rouge/lexers/http.rb
@@ -7,8 +7,8 @@ module Rouge
       title "HTTP"
       desc 'http requests and responses'
 
-      def self.methods
-        @methods ||= %w(GET POST PUT DELETE HEAD OPTIONS TRACE PATCH)
+      def self.http_methods
+        @http_methods ||= %w(GET POST PUT DELETE HEAD OPTIONS TRACE PATCH)
       end
 
       def content_lexer
@@ -24,7 +24,7 @@ module Rouge
       state :root do
         # request
         rule %r(
-          (#{HTTP.methods.join('|')})([ ]+) # method
+          (#{HTTP.http_methods.join('|')})([ ]+) # method
           ([^ ]+)([ ]+)                     # path
           (HTTPS?)(/)(1[.][01])(\r?\n|$)  # http version
         )ox do

--- a/spec/guesser_spec.rb
+++ b/spec/guesser_spec.rb
@@ -1,0 +1,30 @@
+describe Rouge::Guesser do
+  include Support::Guessing
+
+  describe 'guessing with custom globs' do
+    it 'guesses correctly' do
+      assert_guess(Rouge::Lexers::Javascript,
+        :custom_globs => [['*.pl', 'javascript']],
+        :filename => 'oddly-named.pl'
+      )
+    end
+  end
+
+  describe 'guessing with custom guessing strategies' do
+    it 'guesses in order' do
+      assert_guess(Rouge::Lexers::Ruby,
+        :guessers => [
+          Rouge::Guessers::Source.new('#!/usr/bin/env ruby'),
+          Rouge::Guessers::Filename.new('foo.md'),
+        ]
+      )
+
+      assert_guess(Rouge::Lexers::Markdown,
+        :guessers => [
+          Rouge::Guessers::Filename.new('foo.md'),
+          Rouge::Guessers::Source.new('#!/usr/bin/env ruby'),
+        ]
+      )
+    end
+  end
+end

--- a/spec/guesser_spec.rb
+++ b/spec/guesser_spec.rb
@@ -62,7 +62,8 @@ describe Rouge::Guesser do
 
   describe 'modeline guessing' do
     it 'guesses by modeline' do
-      assert_guess(Rouge::Lexers::Ruby, :source => '# vim: syntax=ruby')
+      # don't confuse actual editors when opening this file lol
+      assert_guess(Rouge::Lexers::Ruby, :source => '# v' + 'im: syntax=ruby')
     end
   end
 end

--- a/spec/guesser_spec.rb
+++ b/spec/guesser_spec.rb
@@ -58,6 +58,14 @@ describe Rouge::Guesser do
         ]
       )
     end
+
+    it 'filters with a lambda' do
+      assert_guess(Rouge::Lexers::C,
+        :guessers => [
+          ->(lexers) { [ Rouge::Lexers::C ] }
+        ]
+      )
+    end
   end
 
   describe 'modeline guessing' do

--- a/spec/guesser_spec.rb
+++ b/spec/guesser_spec.rb
@@ -59,4 +59,10 @@ describe Rouge::Guesser do
       )
     end
   end
+
+  describe 'modeline guessing' do
+    it 'guesses by modeline' do
+      assert_guess(Rouge::Lexers::Ruby, :source => '# vim: syntax=ruby')
+    end
+  end
 end

--- a/spec/guesser_spec.rb
+++ b/spec/guesser_spec.rb
@@ -26,5 +26,37 @@ describe Rouge::Guesser do
         ]
       )
     end
+
+    it 'uses custom guessers' do
+      passed_lexers = nil
+
+      custom = Class.new(Rouge::Guesser) {
+        define_method(:filter) { |lexers|
+          passed_lexers = lexers
+
+          [Rouge::Lexers::Javascript]
+        }
+      }.new
+
+      assert_guess(Rouge::Lexers::Javascript, :guessers => [custom])
+      assert { passed_lexers.size == Rouge::Lexer.all.size }
+    end
+
+    it 'sequentially filters' do
+      custom = Class.new(Rouge::Guesser) {
+        define_method(:filter) { |lexers|
+          passed_lexers = lexers
+
+          [Rouge::Lexers::Javascript, Rouge::Lexers::Prolog]
+        }
+      }.new
+
+      assert_guess(Rouge::Lexers::Prolog,
+        :guessers => [
+          custom,
+          Rouge::Guessers::Filename.new('foo.pl'),
+        ]
+      )
+    end
   end
 end

--- a/spec/lexers/c_spec.rb
+++ b/spec/lexers/c_spec.rb
@@ -8,6 +8,7 @@ describe Rouge::Lexers::C do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.c'
+      assert_guess :filename => 'FOO.C'
       assert_guess :filename => 'foo.h', :source => 'foo'
     end
 


### PR DESCRIPTION
TODO before merge:

- [ ] Documentation

This pull request breaks apart the monolithic guessing code into a strategy-pattern system based on Guessers. A Guesser is an object with a method `filter(lexers)` that returns a smaller list of lexers (for convenience, returning an empty list is equivalent to returning the input unchanged). Rouge includes a number of builtin guessers, including `Guesser::Filename`, and `Guesser::Source`, for guessing by filename and text analysis, respectively.

To use custom guessers, call `Lexer.guess(guessers: list_of_guessers)`.

In particular, we include a `GlobMatch` guesser for custom glob mappings. Usage:

```
# This guesser will filter down to just prolog, despite *.pl usually being used for Perl
guesser = GlobMatch.by_pairs([
  ['*.pl', 'prolog'],
], 'foo.pl')
```

Update 6/9:

* Filename guessing is now case insensitive (cf #494).
* A lambda [lexers] -> [lexers] is now acceptable in lieu of a full-on Guesser object.