### PR TITLE
Praat: Minor fixes to interpolation rules

### DIFF
--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -275,7 +275,7 @@ module Rouge
       end
 
       state :string_interpolated do
-        rule /'[_a-z][^\[\]'":]*(\[([\d,]+|"[\w\d,]+")\])?(:[0-9]+)?'/, Literal::String::Interpol
+        rule /'[\._a-z][^\[\]'":]*(\[([\d,]+|"[\w\d,]+")\])?(:[0-9]+)?'/, Literal::String::Interpol
       end
 
       state :string_unquoted do

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -275,7 +275,7 @@ module Rouge
       end
 
       state :string_interpolated do
-        rule /'[^['"]]+(\[([\w\d,]+|"[\w\d,]+")\])?'/, Literal::String::Interpol
+        rule /'[_a-z][^\[\]'":]*(\[([\d,]+|"[\w\d,]+")\])?(:[0-9]+)?'/, Literal::String::Interpol
       end
 
       state :string_unquoted do

--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -83,6 +83,22 @@ else macintosh == 1
   exit We are on Mac
 endif
 
+# Interpolation with precision digits
+echo unquoted 'a:3'
+echo unquoted 'a.a:3'
+echo unquoted 'a[1]:3'
+echo unquoted 'a1:3'
+
+appendInfoLine: "quoted 'a:3'"
+appendInfoLine: "quoted 'a.a:3'"
+appendInfoLine: "quoted 'a[1]:3'"
+appendInfoLine: "quoted 'a1:3'"
+
+# Interpolations are not recursive
+echo unquoted 'a'1':3'
+appendInfoLine: "quoted 'a'1':3'"
+
+# Interpolation without precision digits
 echo unquoted 'var' numeric
 echo unquoted 'var$' string
 echo unquoted 'var["a"]' numeric hash
@@ -96,6 +112,10 @@ appendInfoLine: "quoted 'var["a"]' numeric hash"
 appendInfoLine: "quoted 'var$["a"]' string hash"
 appendInfoLine: "quoted 'var[1]' numeric indexed variable"
 appendInfoLine: "quoted 'var$[1]' string indexed variable"
+
+# Indeces in interpolations must be literal
+echo 'var[a]'
+echo 'var[a$]'
 
 string$ = "But don't interpolate everything!"
 string$ = "interpolatin' " + "across" + " strings ain't cool either"
@@ -295,7 +315,7 @@ procedure newStyle (.str1$, .num, .str2$)
   .local = Get total duration
   .local = Get 'some' duration
   .local = Get 'some[1]' value... hello 10 p[i]
-  .local = Get 'some[1,3]' value: "hello", 10, 'p[i]'
+  .local = Get 'some[1,3]' value: "hello", 10, p[i]
   .local = Get 'some$' duration
   .local = Get 'some$[1]' duration
 endproc


### PR DESCRIPTION
The lexer incorrectly interpolated indexed variables with non-literal indeces (which were removed from the visual spec). This pull request fixexs that.

The visual spec was also extended to include other interpolation samples with precision digits.