### PR TITLE
Fix support for Liquid variable ending in question marks.

### DIFF
--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -210,7 +210,7 @@ module Rouge
 
       state :variable do
         rule /\.(?=\w)/, Punctuation
-        rule /[a-zA-Z_]\w*/, Name::Variable
+        rule /[a-zA-Z_]\w*\??/, Name::Variable
       end
 
       state :string do

--- a/spec/visual/samples/liquid
+++ b/spec/visual/samples/liquid
@@ -24,6 +24,7 @@ Just regular text - what happens?
 {{ var.field | textilize | markdownify }}
 {{ var.field.property | textilize | markdownify }}
 {{ 'string' | truncate: 100 param='df"g' }}
+{{ variable.nil? }}
 
 {% capture name %}
 {{ title | downcase }}


### PR DESCRIPTION
Liquid variable names can end in question marks. See the [`Liquid:: VariableParser ` constant](https://github.com/Shopify/liquid/blob/master/lib/liquid.rb#L40). Currently the question mark part of the variable name is rendered as an error and this pull request provides a fix.