### PR TITLE
Fix C# comment regex

### DIFF
--- a/lib/rouge/lexers/csharp.rb
+++ b/lib/rouge/lexers/csharp.rb
@@ -43,7 +43,7 @@ module Rouge
 
       state :whitespace do
         rule /\s+/m, Text
-        rule %r(//.*?\n), Comment::Single
+        rule %r(//.*?$), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
       end
 


### PR DESCRIPTION
This fixes an issue where a single-line comment without a `\n` at the end of input will not be rougified as a comment. For example, consider the following block of text:
```
if (condition)
    // do something
else
    // do something else
```
The `// do something else` line will not be properly rougified. This behavior can be confirmed on the Rouge home page. Just enter the text above and select C#. The last line will not be rougified _unless_ it is followed by a newline. You can also see an example of this at http://jeffreypratt.net/what-if-your-factory-method-cant-create-anything.html.

My fix changes the single line comment regex to no longer require a newline at the end, and instead uses the regex end-of-line (`$`), similar to the regex for Java single-line comments.