### PR TITLE
Add ES6 string interpolation for JavaScript

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -139,6 +139,11 @@ module Rouge
         rule /;/, Punctuation, :statement
         rule /[)\].]/, Punctuation
 
+        rule /`/ do
+          token Str::Double
+          push :template_string
+        end
+
         rule /[?]/ do
           token Punctuation
           push :ternary
@@ -217,6 +222,32 @@ module Rouge
         rule /:/ do
           token Punctuation
           goto :expr_start
+        end
+
+        mixin :root
+      end
+
+      # template strings
+      state :template_string do
+        rule /\${/ do
+          token Punctuation
+          push :template_string_expr
+        end
+
+        rule /`/ do
+          token Str::Double
+          pop!
+        end
+
+        rule /(\\\\|\\[\$`]|[^\$`]|\$[^{])*/ do
+          token Str::Double
+        end
+      end
+
+      state :template_string_expr do
+        rule /}/ do
+          token Punctuation
+          pop!
         end
 
         mixin :root

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -199,3 +199,10 @@ function* range(from, to)
     yield from++;
   }
 }
+
+// string interpolation
+`this is ${"sparta".toUpperCase()}`;
+
+// nasty string interpolation
+`this\n \` \${2} $` is\n ${"sparta".toUpperCase() + function() { return 4; } + "h"}`;
+`hello ${"${re}" + `curs${1}on`}`;


### PR DESCRIPTION
Adds support for string interpolation as specified by ECMAScript 6.

Example:
```javascript
let string = `this is ${"sparta".toUpperCase()}`;
```