### PR TITLE
Improvements in the handling of non-conventional procedure names

### DIFF
--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -37,7 +37,7 @@ module Rouge
         demoOptionKeyPressed demoShiftKeyPressed demoShow demoWaitForInput
         demoWindowTitle demoX demoY differenceLimensToPhon do editor endPause
         endSendPraat endsWith erb erbToHertz erf erfc exitScript exp
-        extractNumber fileReadable fisherP fisherQ floor gaussP gaussQ
+        extractNumber fileReadable fisherP fisherQ floor gaussP gaussQ hash
         hertzToBark hertzToErb hertzToMel hertzToSemitones imax imin
         incompleteBeta incompleteGammaP index index_regex integer invBinomialP
         invBinomialQ invChiSquareQ invFisherQ invGaussQ invSigmoid invStudentQ

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -107,8 +107,17 @@ module Rouge
         rule /^#.*?$/,         Comment::Single
         rule /;[^\n]*/,        Comment::Single
         rule /\s+/,            Text
-        rule /\bprocedure\s+/, Keyword,        :procedure_definition
-        rule /\bcall\s+/,      Keyword,        :procedure_call
+
+        rule /(\bprocedure)(\s+)/ do
+          groups Keyword, Text
+          push :procedure_definition
+        end
+
+        rule /(\bcall)(\s+)/ do
+          groups Keyword, Text
+          push :procedure_call
+        end
+
         rule /@/,              Name::Function, :procedure_call
 
         mixin :function_call

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -104,12 +104,12 @@ module Rouge
           groups Text, Comment::Single
         end
 
-        rule /^#.*?$/,        Comment::Single
-        rule /;[^\n]*/,       Comment::Single
-        rule /\s+/,           Text
-        rule /\bprocedure\b/, Keyword,        :procedure_definition
-        rule /\bcall\b/,      Keyword,        :procedure_call
-        rule /@/,             Name::Function, :procedure_call
+        rule /^#.*?$/,         Comment::Single
+        rule /;[^\n]*/,        Comment::Single
+        rule /\s+/,            Text
+        rule /\bprocedure\s+/, Keyword,        :procedure_definition
+        rule /\bcall\s+/,      Keyword,        :procedure_call
+        rule /@/,              Name::Function, :procedure_call
 
         mixin :function_call
 
@@ -142,7 +142,7 @@ module Rouge
       end
 
       state :command do
-        rule /( ?[\w()-]+ ?)/, Keyword
+        rule /( ?([^\s:\.'])+ ?)/, Keyword
         mixin :string_interpolated
 
         rule /\.{3}/ do
@@ -161,32 +161,26 @@ module Rouge
       end
 
       state :procedure_call do
-        rule /\s+/, Text
+        mixin :string_interpolated
 
-        rule /([\w.]+)(:|\s*\()/ do
-          groups Name::Function, Punctuation
-          pop!
-        end
+        rule /(:|\s*\()/, Punctuation, :pop!
 
-        rule /([\w.]+)/ do
-          token Name::Function
+        rule /'/,            Name::Function
+        rule /[^:\('\n\s]+/, Name::Function
+
+        rule /(?=\s+)/ do
+          token Text
           pop!
           push :old_arguments
         end
       end
 
       state :procedure_definition do
-        rule /\s/, Text
+        rule /(:|\s*\()/, Punctuation, :pop!
 
-        rule /([\w.]+)(\s*?[(:])/ do
-          groups Name::Function, Text
-          pop!
-        end
+        rule /[^:\(\n\s]+/, Name::Function
 
-        rule /([\w.]+)([^\n]*)/ do
-          groups Name::Function, Text
-          pop!
-        end
+        rule /(\s+)/, Text, :pop!
       end
 
       state :function_call do

--- a/spec/lexers/praat_spec.rb
+++ b/spec/lexers/praat_spec.rb
@@ -10,6 +10,51 @@ describe Rouge::Lexers::Praat do
       assert_guess :filename => 'foo.praat'
       assert_guess :filename => 'foo.proc'
     end
+  end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'unquoted string directives' do
+      assert_tokens_equal "echo unquoted 1",
+        ['Keyword',        'echo'],
+        ['Text',           ' '],
+        ['Literal.String', 'unquoted 1']
+    end
+
+    it 'string function' do
+      assert_tokens_equal "string$()",
+        ['Name.Function',  'string$'],
+        ['Text',           '()']
+    end
+
+    it 'string variable' do
+      assert_tokens_equal "string$",
+        ['Text',           'string$']
+    end
+
+    it 'shorthand procedure call' do
+      assert_tokens_equal 'call procedure "arg" 1 unquoted',
+        ['Keyword',        'call'],
+        ['Text',           ' '],
+        ['Name.Function',  'procedure'],
+        ['Text',           ' '],
+        ['Literal.String', '"arg"'],
+        ['Text',           ' '],
+        ['Literal.Number', '1'],
+        ['Text',           ' unquoted']
+    end
+
+    it 'new-style procedure call' do
+      assert_tokens_equal '@procedure: "arg", 1',
+        ['Name.Function',  '@procedure'],
+        ['Punctuation',    ':'],
+        ['Text',           ' '],
+        ['Literal.String', '"arg"'],
+        ['Punctuation',    ','],
+        ['Text',           ' '],
+        ['Literal.Number', '1']
+    end
 
   end
 end

--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -176,6 +176,8 @@ endif
 # inline if with inline comment
 var = if macintosh = 1 then 0 else 1 fi ; This is an inline comment
 
+Remove ; Not an inline comment!
+
 # for-loop with explicit from using local variable
 # and paren-style function calls and variable interpolation
 n = numberOfSelected("Sound")

--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -146,6 +146,26 @@ select  all
 call oldStyle "quoted" 2 unquoted string
 assert oldStyle.local = 1
 
+# Interpolated procedure names
+procname$ = "newStyle"
+@'procname$':    "quoted", 2, "quoted string"
+call 'procname$' "quoted" "2" unquoted string
+
+# Funky procedure names!
+@@%^&()
+@#.!: "a"
+call # 2
+call # "string" 2 unquoted
+
+procedure @#@#!
+endproc
+
+procedure 'not_expansion$': .var
+endproc
+
+procedure 'not_expansion$' (.var)
+endproc
+
 # New-style procedure call with parens
 @newStyle("quoted", 2, "quoted string")
 if praatVersion >= 5364

--- a/spec/visual/samples/praat
+++ b/spec/visual/samples/praat
@@ -364,3 +364,9 @@ endfor
   ... "selected sound is tone")
 
 @ok_formula("selected$(""Sound"") = ""tone""", "selected sound is tone")
+
+call try
+  ... 'newline$' # This is really all a string, but it is undetectable
+  ... 'newline$' # without knowing the arguments for the procedure
+  ... 'newline$' assert "hello" =  "he" + "llo"
+  ... 'newline$' assert "hello" == "hello world" - " world"


### PR DESCRIPTION
I wasn't aware Praat allowed pretty much any character as part of a procedure name. This PR fixes this.

It also adds some other bug fixes, eg with "inline comments", which do not always behave like you'd expect, and an undocumented function I came across the other day.

I've also added tests to the visual spec, but is there any way to add and run automatic tests? I know they use them in pygments.
