### PR TITLE
Python raw string escape fix

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -204,7 +204,7 @@ module Rouge
         rule %r(\\
           ( [\\abfnrtv"']
           | \n
-          | N{.*?}
+          | N{[a-zA-z][a-zA-Z ]+[a-zA-Z]}
           | u[a-fA-F0-9]{4}
           | U[a-fA-F0-9]{8}
           | x[a-fA-F0-9]{2}

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -107,14 +107,14 @@ module Rouge
 
         # TODO: not in python 3
         rule /`.*?`/, Str::Backtick
-        rule /(?:r|ur|ru)"""/i, Str, :tdqs
-        rule /(?:r|ur|ru)'''/i, Str, :tsqs
-        rule /(?:r|ur|ru)"/i,   Str, :dqs
-        rule /(?:r|ur|ru)'/i,   Str, :sqs
-        rule /u?"""/i,          Str, :escape_tdqs
-        rule /u?'''/i,          Str, :escape_tsqs
-        rule /u?"/i,            Str, :escape_dqs
-        rule /u?'/i,            Str, :escape_sqs
+        rule /(?:r|ur|ru)"""/i, Str, :raw_tdqs
+        rule /(?:r|ur|ru)'''/i, Str, :raw_tsqs
+        rule /(?:r|ur|ru)"/i,   Str, :raw_dqs
+        rule /(?:r|ur|ru)'/i,   Str, :raw_sqs
+        rule /u?"""/i,          Str, :tdqs
+        rule /u?'''/i,          Str, :tsqs
+        rule /u?"/i,            Str, :dqs
+        rule /u?'/i,            Str, :sqs
 
         rule /@#{dotted_identifier}/i, Name::Decorator
 
@@ -213,21 +213,26 @@ module Rouge
         )x, Str::Escape
       end
 
+      state :raw_escape do
+        rule /\\./, Str
+      end
+
       state :dqs do
         rule /"/, Str, :pop!
-        rule /\\\\|\\"|\\\n/, Str::Escape
+        mixin :escape
         mixin :strings_double
       end
 
       state :sqs do
         rule /'/, Str, :pop!
-        rule /\\\\|\\'|\\\n/, Str::Escape
+        mixin :escape
         mixin :strings_single
       end
 
       state :tdqs do
         rule /"""/, Str, :pop!
         rule /"/, Str
+        mixin :escape
         mixin :strings_double
         mixin :nl
       end
@@ -235,13 +240,14 @@ module Rouge
       state :tsqs do
         rule /'''/, Str, :pop!
         rule /'/, Str
+        mixin :escape
         mixin :strings_single
         mixin :nl
       end
 
       %w(tdqs tsqs dqs sqs).each do |qtype|
-        state :"escape_#{qtype}" do
-          mixin :escape
+        state :"raw_#{qtype}" do
+          mixin :raw_escape
           mixin :"#{qtype}"
         end
       end

--- a/spec/visual/samples/python
+++ b/spec/visual/samples/python
@@ -39,6 +39,24 @@ def baz():
 def zap():
     """docstring"""
 
+# escaped characters in string literals
+def baz():
+    '\a\b\f\n\r\t\v\"\''
+    '\N{DEGREE SIGN}'
+    '\uaF09'
+    '\UaaaaAF09'
+    '\xaf\xAF\x09'
+    '\007'
+
+# escaped characters in raw strings
+def baz():
+    r'\a\b\f\n\r\t\v\"\''
+    r'\N{DEGREE SIGN}'
+    r'\uaF09'
+    r'\UaaaaAF09'
+    r'\xaf\xAF\x09'
+    r'\007'
+
 # line continuations
 apple.filter(x, y)
 apple.\


### PR DESCRIPTION
This PR fixes #306.

Before:
<img width="343" alt="screen shot 2016-07-14 at 4 36 17 pm" src="https://cloud.githubusercontent.com/assets/294415/16854988/544bc118-49e1-11e6-831e-bf55757aff57.png">

After:
<img width="350" alt="screen shot 2016-07-14 at 4 30 37 pm" src="https://cloud.githubusercontent.com/assets/294415/16854997/5dd20328-49e1-11e6-8f2e-21d70e6db75e.png">

`vi` for comparison:
![screen shot 2016-07-14 at 4 30 20 pm](https://cloud.githubusercontent.com/assets/294415/16855074/bedefea0-49e1-11e6-9b14-78fe7b4e885e.png)

This PR also improves the regex for the unicode character name escape sequence, which was a little too accepting.