### PR TITLE
Add Turtle/TriG lexer

### DIFF
--- a/lib/rouge/demos/turtle
+++ b/lib/rouge/demos/turtle
@@ -21,5 +21,6 @@ GRAPH <https://trig.testing.graph> {
     dcat:contactPoint [ a foaf:Person ] ;
     test:list ( <http://ex.org> 1 1.1 +1 -1 1.2E+4 "Test" "\"Quote\"" ) ;
     test:datatype "2016-07-20"^^xsd:date ;
+    test:text """next multiline""";
     .
 }

--- a/lib/rouge/demos/turtle
+++ b/lib/rouge/demos/turtle
@@ -1,0 +1,25 @@
+@prefix xsd:          <http://www.w3.org/2001/XMLSchema#>
+@prefix dcat:         <http://www.w3.org/ns/dcat#> .
+@prefix dcterms:      <http://purl.org/dc/terms/> .
+@prefix foaf:         <http://xmlns.com/foaf/0.1/> .
+@base                 <http://base.of.relative.iris> .
+
+PREFIX  test:         <http://example.org>
+PrEfIx  insensitive:  <http://insensitive.example.org>
+
+GRAPH <https://trig.testing.graph> {
+    <https://example.org/resource/dataset> a dcat:Dataset ; 
+
+#-----Mandatory-----#
+
+    dcterms:title 'Test title'@cs, "Test title"@en ;
+    dcterms:description """Multiline
+        string"""@cs, '''Another
+        multiline string '''@en ;
+
+#-----Recommended-----#
+    dcat:contactPoint [ a foaf:Person ] ;
+    test:list ( <http://ex.org> 1 1.1 +1 -1 1.2E+4 "Test" "\"Quote\"" ) ;
+    test:datatype "2016-07-20"^^xsd:date ;
+    .
+}

--- a/lib/rouge/lexers/turtle.rb
+++ b/lib/rouge/lexers/turtle.rb
@@ -14,21 +14,21 @@ module Rouge
 
       def self.analyze_text(text)
         start = text[0..1000]
-        return 0.9 if start =~ %r(@prefix\b)
-        return 0.9 if start =~ %r(@base\b)
-        return 0.6 if start =~ %r(PREFIX\b)i
-        return 0.6 if start =~ %r(BASE\b)i
+        return 0.5 if start =~ %r(@prefix\b)
+        return 0.5 if start =~ %r(@base\b)
+        return 0.4 if start =~ %r(PREFIX\b)i
+        return 0.4 if start =~ %r(BASE\b)i
       end
 
       state :root do
-        rule /@base /, Keyword::Declaration
-        rule /@prefix /, Keyword::Declaration
-        rule /true/, Keyword::Constant
-        rule /false/, Keyword::Constant
+        rule /@base\b/, Keyword::Declaration
+        rule /@prefix\b/, Keyword::Declaration
+        rule /true\b/, Keyword::Constant
+        rule /false\b/, Keyword::Constant
         
-        rule /""".*"""/m, Literal::String
+        rule /""".*?"""/m, Literal::String
         rule /"([^"\\]|\\.)*"/, Literal::String
-        rule /'''.*'''/m, Literal::String
+        rule /'''.*?'''/m, Literal::String
         rule /'([^'\\]|\\.)*'/, Literal::String
         
         rule /#.*$/, Comment::Single
@@ -56,12 +56,12 @@ module Rouge
         
         rule /<[^>]*>/, Name::Label
 
-        rule /base /i, Keyword::Declaration
-        rule /prefix /i, Keyword::Declaration
-        rule /GRAPH /, Keyword
-        rule /a /, Keyword
+        rule /base\b/i, Keyword::Declaration
+        rule /prefix\b/i, Keyword::Declaration
+        rule /GRAPH\b/, Keyword
+        rule /a\b/, Keyword
 
-        rule /\s/, Text::Whitespace
+        rule /\s+/, Text::Whitespace
 
         rule /[^:;<>#@"\(\).\[\]\{\} ]+:/, Name::Namespace
         rule /[^:;<>#@"\(\).\[\]\{\} ]+/, Name

--- a/lib/rouge/lexers/turtle.rb
+++ b/lib/rouge/lexers/turtle.rb
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class Turtle < RegexLexer
+      title "Turtle/TriG"
+      desc "Terse RDF Triple Language, TriG"
+      tag 'turtle'
+      filenames *%w(*.ttl *.trig)
+      mimetypes *%w(
+        text/turtle
+        application/trig
+      )
+
+      def self.analyze_text(text)
+        start = text[0..1000]
+        return 0.9 if start =~ %r(@prefix\b)
+      end
+
+      state :root do
+        rule /@base /, Keyword::Declaration
+        rule /@prefix /, Keyword::Declaration
+        rule /true/, Keyword::Constant
+        rule /false/, Keyword::Constant
+        
+        rule /""".*"""/m, Literal::String
+        rule /"([^"\\]|\\.)*"/, Literal::String
+        rule /'''.*'''/m, Literal::String
+        rule /'([^'\\]|\\.)*'/, Literal::String
+        
+        rule /#.*$/, Comment::Single
+        
+        rule /@[^\s,.; ]+/, Name::Attribute
+        
+        rule /[+-]?[0-9]+\.[0-9]*E[+-]?[0-9]+/, Literal::Number::Float
+        rule /[+-]?\.[0-9]+E[+-]?[0-9]+/, Literal::Number::Float
+        rule /[+-]?[0-9]+E[+-]?[0-9]+/, Literal::Number::Float
+
+        rule /[+-]?[0-9]*\.[0-9]+?/, Literal::Number::Float
+
+        rule /[+-]?[0-9]+/, Literal::Number::Integer
+
+        rule /\./, Punctuation
+        rule /,/, Punctuation
+        rule /;/, Punctuation
+        rule /\(/, Punctuation
+        rule /\)/, Punctuation
+        rule /\{/, Punctuation
+        rule /\}/, Punctuation
+        rule /\[/, Punctuation
+        rule /\]/, Punctuation
+        rule /\^\^/, Punctuation
+        
+        rule /<[^>]*>/, Name::Label
+
+        rule /base /i, Keyword::Declaration
+        rule /prefix /i, Keyword::Declaration
+        rule /GRAPH /, Keyword
+        rule /a /, Keyword
+
+        rule /\s/, Text::Whitespace
+
+        rule /[^:;<>#@"\(\).\[\]\{\} ]+:/, Name::Namespace
+        rule /[^:;<>#@"\(\).\[\]\{\} ]+/, Name
+        
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/turtle.rb
+++ b/lib/rouge/lexers/turtle.rb
@@ -15,6 +15,9 @@ module Rouge
       def self.analyze_text(text)
         start = text[0..1000]
         return 0.9 if start =~ %r(@prefix\b)
+        return 0.9 if start =~ %r(@base\b)
+        return 0.6 if start =~ %r(PREFIX\b)i
+        return 0.6 if start =~ %r(BASE\b)i
       end
 
       state :root do

--- a/spec/lexers/turtle_spec.rb
+++ b/spec/lexers/turtle_spec.rb
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Turtle do
+  let(:subject) { Rouge::Lexers::Turtle.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.ttl'
+      assert_guess :filename => 'foo.trig'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/turtle'
+      assert_guess :mimetype => 'application/trig'
+    end
+
+    it 'guesses by source' do
+      assert_guess :source => '@base'
+      assert_guess :source => '@prefix'
+    end
+  end
+end

--- a/spec/visual/samples/turtle
+++ b/spec/visual/samples/turtle
@@ -1,0 +1,60 @@
+
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema:  <http://schema.org/> .
+@prefix vcard:   <http://www.w3.org/2006/vcard/ns#> .
+@prefix void:    <http://rdfs.org/ns/void#> .
+@prefix xml:     <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix adms:    <http://www.w3.org/ns/adms#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix spdx:    <http://spdx.org/rdf/terms#> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix org:     <http://www.w3.org/ns/org#> .
+
+<https://data.cssz.cz/resource/dataset/zanikle-duchody> a dcat:Dataset ;
+
+#-----Mandatory-----#
+
+    dcterms:title "Počet zaniklých důchodů v České republice"@cs, "Number of deprecated pensions in the Czech Republic"@en ;
+    dcterms:description "Počet zaniklých důchodů v České republice podle roku, druhu penze, statistického důvodu zániku a pohlaví"@cs, "Number of deprecated pensions in the Czech Republic according to years, pension kinds and sex."@en ;
+
+#-----Recommended-----#
+    dcat:contactPoint <https://data.cssz.cz/resource/dataset/zanikle-duchody/contactPoint> ;
+    dcat:distribution <https://data.cssz.cz/resource/dataset/zanikle-duchody/distribution/csv>, <https://data.cssz.cz/resource/dataset/zanikle-duchody/distribution/rdf> ;
+	dcat:keyword "důchodová ročenka"@cs, "důchodové pojištění"@cs, "statistika"@cs, "statistics"@en ;
+    dcterms:publisher <http://www.cssz.cz> ;
+    dcat:theme <http://publications.europa.eu/resource/authority/data-theme/SOCI>, <http://eurovoc.europa.eu/3751>, <http://eurovoc.europa.eu/5329> ;
+
+#-----Optional-----#
+
+	dcterms:accessRights <https://data.cssz.cz/dataset/zanikle-duchody/rightsStatement> ;
+	dcat:conformsTo <http://purl.org/linked-data/cube#> ;
+	foaf:page <https://data.cssz.cz/documentation/zanikle-duchody.html> ;
+	dcterms:accrualPeriodicity <http://publications.europa.eu/resource/authority/frequency/ANNUAL> ;
+#dcat:hasVersion <> ;
+#dcat:isVersionOf <> ;
+	dcterms:identifier "zanikle-duchody" ;
+    dcat:landingPage <https://data.cssz.cz/dataset/pocet-zaniklych-duchodu-v-ceske-republice> ;
+	dcterms:language <http://publications.europa.eu/resource/authority/language/CES>, <http://publications.europa.eu/resource/authority/language/ENG> ;
+	adms:identifier <https://data.cssz.cz/resource/dataset/zanikle-duchody/id1>, <https://data.cssz.cz/resource/dataset/zanikle-duchody/id2> ;
+#dct:provenance <>;
+	dcterms:relation <https://data.cssz.cz/resource/dataset/invalidita>, <https://data.cssz.cz/resource/dataset/pocet-vyplacenych-invalidnich-duchodu-v-ceske-republice> ;
+	dcterms:issued "2015-09-30T09:00:01"^^xsd:dateTime ;
+    adms:sample <https://data.cssz.cz/resource/dataset/zanikle-duchody/distribution/rdf>, <https://data.cssz.cz/resource/dataset/zanikle-duchody/distribution/csv> ;
+    dcterms:source <https://data.cssz.cz/resource/dataset/invalidita>, <https://data.cssz.cz/resource/dataset/pocet-vyplacenych-invalidnich-duchodu-v-ceske-republice> ;
+    dcterms:spatial <http://publications.europa.eu/resource/authority/country/CZE>, <http://ruian.linked.opendata.cz/resource/staty/1> ;
+    dcterms:temporal <https://data.cssz.cz/resource/dataset/zanikle-duchody/temporal> ;
+    dcterms:type <http://publications.europa.eu/resource/authority/datasetType/Open> ; # UNOFFICIAL, TBD
+	dcterms:modified "2015-09-06T23:59:12"^^xsd:dateTime ;
+	owl:versionInfo "5.0" ;
+	adms:versionNotes "Lepší než předtim"@cs, "This version is better"@en .
+	
+	<https://data.cssz.cz/resource/dataset/zanikle-duchody/id1> a adms:Identifier ;
+	skos:notation "https://data.cssz.cz/dataset/pocet-zaniklych-duchodu-v-ceske-republice"^^<http://purl.org/spar/datacite/url> .
+
+	<https://data.cssz.cz/resource/dataset/zanikle-duchody/id2> a adms:Identifier ;
+	skos:notation "https://data.cssz.cz/dataset/zanikle-duchody"^^<http://purl.org/spar/datacite/url> .


### PR DESCRIPTION
Implements a lexer for RDF formats [Turtle](https://www.w3.org/TR/turtle/) and [TriG](https://www.w3.org/TR/trig/) - It is only one lexer as TriG is based on Turtle and adds only one keyword and one bracket type.