### PR TITLE
Emit correct tokens for positive numbers in ActionScript

### DIFF
--- a/lib/rouge/lexers/actionscript.rb
+++ b/lib/rouge/lexers/actionscript.rb
@@ -146,9 +146,9 @@ module Rouge
           end
         end
 
-        rule /\-[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?/, Num::Float
+        rule /\-?[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?/, Num::Float
         rule /0x[0-9a-fA-F]+/, Num::Hex
-        rule /\-[0-9]+/, Num::Integer
+        rule /\-?[0-9]+/, Num::Integer
         rule /"(\\\\|\\"|[^"])*"/, Str::Double
         rule /'(\\\\|\\'|[^'])*'/, Str::Single
       end


### PR DESCRIPTION
Only negative numbers were being recognized as integers and floats.