### PR TITLE
Elixir sigils and regexps

### DIFF
--- a/lib/rouge/lexers/elixir.rb
+++ b/lib/rouge/lexers/elixir.rb
@@ -15,13 +15,6 @@ module Rouge
 
       mimetypes 'text/x-elixir', 'application/x-elixir'
 
-      BRACES = [
-        ['\{', '\}', 'cb'],
-        ['\[', '\]', 'sb'],
-        ['\(', '\)', 'pa'],
-        ['\<', '\>', 'lt']
-      ]
-
       state :root do
         rule /\s+/m, Text
         rule /#.*$/, Comment::Single
@@ -46,9 +39,9 @@ module Rouge
         rule /@[a-zA-Z_]\w*|&\d/, Name::Variable
         rule %r{\b(0[xX][0-9A-Fa-f]+|\d(_?\d)*(\.(?![^\d\s])
              (_?\d)*)?([eE][-+]?\d(_?\d)*)?|0[bB][01]+)\b}x, Num
-        rule %r{~r\/.*\/}, Str::Regex
 
         mixin :strings
+        mixin :sigil_strings
       end
 
       state :strings do
@@ -58,25 +51,6 @@ module Rouge
         rule /'.*?'/, Str::Single
         rule %r{(?<!\w)\?(\\(x\d{1,2}|\h{1,2}(?!\h)\b|0[0-7]{0,2}(?![0-7])\b[^x0MC])|(\\[MC]-)+\w|[^\s\\])}, Str::Other
 
-        BRACES.each do |_, _, name|
-          mixin :"braces_#{name}"
-        end
-      end
-
-      BRACES.each do |lbrace, rbrace, name|
-        state :"braces_#{name}" do
-          rule /%[a-z]#{lbrace}/, Str::Double, :"braces_#{name}_intp"
-          rule /%[A-Z]#{lbrace}/, Str::Double, :"braces_#{name}_no_intp"
-        end
-
-        state :"braces_#{name}_intp" do
-          rule /#{rbrace}[a-z]*/, Str::Double, :pop!
-          mixin :enddoublestr
-        end
-
-        state :"braces_#{name}_no_intp" do
-          rule /.*#{rbrace}[a-z]*/, Str::Double, :pop!
-        end
       end
 
       state :dqs do
@@ -102,6 +76,65 @@ module Rouge
       state :enddoublestr do
         mixin :interpoling
         rule /[^#"]+/, Str::Double
+      end
+
+      state :sigil_strings do
+        # ~-sigiled strings
+        # ~(abc), ~[abc], ~<abc>, ~|abc|, ~r/abc/, etc
+        # Cribbed and adjusted from Ruby lexer
+        delimiter_map = { '{' => '}', '[' => ']', '(' => ')', '<' => '>' }
+        # Match a-z for custom sigils too
+        sigil_opens = Regexp.union(delimiter_map.keys + %w(| / ' "))
+        rule /~([A-Za-z])?(#{sigil_opens})/ do |m|
+          open = Regexp.escape(m[2])
+          close = Regexp.escape(delimiter_map[m[2]] || m[2])
+          interp = /[SRCW]/ === m[1]
+          toktype = Str::Other
+
+          puts "    open: #{open.inspect}" if @debug
+          puts "    close: #{close.inspect}" if @debug
+
+          # regexes
+          if 'Rr'.include? m[1]
+            toktype = Str::Regex
+            push :regex_flags
+          end
+
+          if 'Ww'.include? m[1]
+            push :list_flags
+          end
+
+          token toktype
+
+          push do
+            # rule /\\[##{open}#{close}\\]/, Str::Escape
+            # # nesting rules only with asymmetric delimiters
+            # if open != close
+            #   rule /#{open}/ do
+            #     token toktype
+            #     push
+            #   end
+            # end
+            rule /#{close}/, toktype, :pop!
+
+            if interp
+              mixin :interpoling
+              rule /#/, toktype
+            else
+              rule /[\\#]/, toktype
+            end
+
+            rule /[^##{open}#{close}\\]+/m, toktype
+          end
+        end
+      end
+
+      state :regex_flags do
+        rule /[fgimrsux]*/, Str::Regex, :pop!
+      end
+
+      state :list_flags do
+        rule /[csa]?/, Str::Other, :pop!
       end
     end
   end

--- a/lib/rouge/lexers/elixir.rb
+++ b/lib/rouge/lexers/elixir.rb
@@ -107,14 +107,6 @@ module Rouge
           token toktype
 
           push do
-            # rule /\\[##{open}#{close}\\]/, Str::Escape
-            # # nesting rules only with asymmetric delimiters
-            # if open != close
-            #   rule /#{open}/ do
-            #     token toktype
-            #     push
-            #   end
-            # end
             rule /#{close}/, toktype, :pop!
 
             if interp

--- a/spec/lexers/elixir_spec.rb
+++ b/spec/lexers/elixir_spec.rb
@@ -63,8 +63,85 @@ describe Rouge::Lexers::Elixir do
     end
 
     it 'lexes regexp sigils' do
-      assert_tokens_equal %{~r//},
-        ['Literal.String.Regex', '~r//']
+      %w(() [] <> '' "" || //).each do |pair|
+        l, r = pair[0], pair[1]
+        assert_tokens_equal %{~r#{l}#{r}},
+          ['Literal.String.Regex', "~r#{l}#{r}"]
+
+        assert_tokens_equal %{~r#{l}#{r}gif},
+          ['Literal.String.Regex', "~r#{l}#{r}gif"]
+
+        assert_tokens_equal %{~r#{l}abc+foo#{r}rsx},
+          ['Literal.String.Regex', "~r#{l}abc+foo#{r}rsx"]
+
+        assert_tokens_equal %{~r//p}, # Wrong regex modifier gets turned into a Name
+          ['Literal.String.Regex', '~r//'],
+          ['Name', 'p']
+      end
+    end
+
+    it 'lexes regexp sigil avoiding greedy errors' do
+      text = 'string |> String.split(~r/[ -]/) |> Enum.map(&abbreviate_word/1) |> Enum.join()'
+      
+      assert_tokens_equal text,
+        ['Name', 'string'],
+        ['Text', ' '],
+        ['Operator', '|>'],
+        ['Text', ' '],
+        ['Name.Constant', 'String'],
+        ['Operator', '.'],
+        ['Name', 'split'],
+        ['Punctuation', '('],
+        ['Literal.String.Regex', '~r/[ -]/'],
+        ['Punctuation', ')'],
+        ['Text', ' '],
+        ['Operator', '|>'],
+        ['Text', ' '],
+        ['Name.Constant', 'Enum'],
+        ['Operator', '.'],
+        ['Name', 'map'],
+        ['Punctuation', '('],
+        ['Operator', '&'],
+        ['Name', 'abbreviate_word'],
+        ['Operator', '/'],
+        ['Literal.Number', '1'],
+        ['Punctuation', ')'],
+        ['Text', ' '],
+        ['Operator', '|>'],
+        ['Text', ' '],
+        ['Name.Constant', 'Enum'],
+        ['Operator', '.'],
+        ['Name', 'join'],
+        ['Punctuation', '()']
+
+    end
+
+    it 'lexes other sigils' do
+      %w(() [] <> '' "" || //).each do |pair|
+        l, r = pair[0], pair[1]
+        assert_tokens_equal %{~c#{l}#{r}},
+          ['Literal.String.Other', "~c#{l}#{r}"]
+
+        assert_tokens_equal %{~s#{l}ABC#{r}},
+          ['Literal.String.Other', "~s#{l}ABC#{r}"]
+
+
+        assert_tokens_equal %{~w#{l}lorem ipsum dolor#{r}s},
+          ['Literal.String.Other', "~w#{l}lorem ipsum dolor#{r}s"]
+
+        assert_tokens_equal %{~S#{l}#\{inter <> "polation"\}#{r}},
+          ['Literal.String.Other', "~S#{l}"],
+          ['Literal.String.Interpol', '#{'],
+          ['Name', 'inter'],
+          ['Text', ' '],
+          ['Operator', '<>'],
+          ['Text', ' '],
+          ['Literal.String.Doc', '"'],
+          ['Literal.String.Double', 'polation"'],
+          ['Literal.String.Interpol', '}'],
+          ['Literal.String.Other', r]
+      end
+
     end
 
     it 'lexes & operator' do


### PR DESCRIPTION
While parsing rules are the same, it takes care to mark Regexps appropriately.

Also removes old rules that were (incorrectly?) matching `%r()` instead of `~r()`. To my knowledge, such strings are an error in Elixir, maybe these were a typo or copied from an earlier version of Ruby lexer.

This addresses #528, and includes a test for exactly that code. Handles modifiers where applicable - for `~r` and `~w` (different ones).
