### PR TITLE
Update exponent regex in Fortran lexer

### DIFF
--- a/lib/rouge/lexers/fortran.rb
+++ b/lib/rouge/lexers/fortran.rb
@@ -16,7 +16,7 @@ module Rouge
 
       name = /[A-Z][_A-Z0-9]*/i
       kind_param = /(\d+|#{name})/
-      exponent = /[ED][+-]\d+/
+      exponent = /[ED][+-]?\d+/i
 
       def self.keywords
         # Fortran allows to omit whitespace between certain keywords...


### PR DESCRIPTION
In the Fortran specification, the exponent-letter within a
signed-real-literal-constant is case-insensitive and the sign in the
signed-digit-string in the exponent is optional.

This updates the exponent regular expression in the Fortran lexer to
account for both of these.

For example, previously, in an expression like `a = 3.14159d0`, the d0
would be misclassfied as a Name instead of part of the Number.Float.