### PR TITLE
Update TeX guesser

### DIFF
--- a/lib/rouge/lexers/tex.rb
+++ b/lib/rouge/lexers/tex.rb
@@ -8,7 +8,7 @@ module Rouge
       tag 'tex'
       aliases 'TeX', 'LaTeX', 'latex'
 
-      filenames '*.tex', '*.aux', '*.toc'
+      filenames '*.tex', '*.aux', '*.toc', '*.sty', '*.cls'
       mimetypes 'text/x-tex', 'text/x-latex'
 
       def self.analyze_text(text)
@@ -16,6 +16,8 @@ module Rouge
         return 1 if text =~ /\A\s*\\input/
         return 1 if text =~ /\A\s*\\documentstyle/
         return 1 if text =~ /\A\s*\\relax/
+        return 1 if text =~ /\A\s*\\ProvidesPackage/
+        return 1 if text =~ /\A\s*\\ProvidesClass/
       end
 
       command = /\\([a-z]+|\s+|.)/i

--- a/spec/lexers/tex_spec.rb
+++ b/spec/lexers/tex_spec.rb
@@ -10,6 +10,8 @@ describe Rouge::Lexers::TeX do
       assert_guess :filename => 'foo.tex'
       assert_guess :filename => 'foo.toc'
       assert_guess :filename => 'foo.aux'
+      assert_guess :filename => 'foo.sty'
+      assert_guess :filename => 'foo.cls'
     end
 
     it 'guesses by mimetype' do
@@ -18,7 +20,9 @@ describe Rouge::Lexers::TeX do
     end
 
     it 'guesses by source' do
-      assert_guess :source => '\\documentclass{article}'
+      assert_guess :source => '\\documentclass'
+      assert_guess :source => '\\ProvidesPackage'
+      assert_guess :source => '\\ProvidesClass'
     end
   end
 end


### PR DESCRIPTION
- Adds `.sty` and `.cls` as extensions, for style and class files, respectively.
- `\documentclass{article}` is not always used (e.g. `\documentclass[a4paper]{article}` or `\documentclass{book}`), so just `\documentclass` is more reliable
- Adds `\ProvidesPackage` and `\ProvidesClass` source guessers for style and class files, respectively
