### PR TITLE
Handle downstream pipe close

### DIFF
--- a/bin/rougify
+++ b/bin/rougify
@@ -4,6 +4,7 @@ require 'pathname'
 ROOT_DIR = Pathname.new(__FILE__).dirname.parent
 load ROOT_DIR.join('lib/rouge.rb')
 load ROOT_DIR.join('lib/rouge/cli.rb')
+Signal.trap('SIGPIPE', 'SYSTEM_DEFAULT')
 
 begin
   Rouge::CLI.parse(ARGV).run


### PR DESCRIPTION
This would allow `rougify foo | head` to exit silently while setting
`${PIPESTATUS[@]}` properly.
