### PR TITLE
fixing a bug in the coq parser.

### DIFF
--- a/lib/rouge/demos/coq
+++ b/lib/rouge/demos/coq
@@ -9,3 +9,5 @@ Section with_T.
     | _ :: ls => S (length ls)
     end.
 End with_T.
+
+Definition a_string := "hello \" world".

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -150,6 +150,10 @@ module Rouge
         rule /"/, Str::Double, :pop!
       end
 
+      state :escape_sequence do
+        rule /\\[\\"'ntbr]/, Str::Escape
+      end
+
       state :continue_id do
         # the stream starts with an id (stored in @name) and continues here
         rule dot_id do |m|

--- a/spec/visual/samples/coq
+++ b/spec/visual/samples/coq
@@ -10,3 +10,4 @@ Section with_T.
     end.
 End with_T.
 
+Definition a_string := "hello".

--- a/spec/visual/samples/coq
+++ b/spec/visual/samples/coq
@@ -10,4 +10,4 @@ Section with_T.
     end.
 End with_T.
 
-Definition a_string := "hello".
+Definition a_string := "hello\" world".


### PR DESCRIPTION
A bug in the Coq parser prevented it from parsing strings correctly.
- Test case is also updated.
