### PR TITLE
Properly match symbols ending with ? or !

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -79,7 +79,7 @@ module Rouge
 
       state :strings do
         mixin :symbols
-        rule /\b[a-z_]\w*?:\s+/, Str::Symbol, :expr_start
+        rule /\b[a-z_]\w*?[?!]?:\s+/, Str::Symbol, :expr_start
         rule /'(\\\\|\\'|[^'])*'/, Str::Single
         rule /"/, Str::Double, :simple_string
         rule /(?<!\.)`/, Str::Backtick, :simple_backtick

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -17,7 +17,7 @@ end
 
 %i(this is an array of symbols)
 %I(this is too, but with #{@interpolation})
-hash = { answer: 42 }
+hash = { answer: 42, special?: true }
 link_to 'new', new_article_path, class: 'btn'
 
 #####


### PR DESCRIPTION
Ruby symbols can end with a ? or !. This is probably not often
seen. In RSpec, one good example is to stub a method that returns
a boolean value. `allow(foo).to receive_messages(nil?: false)` 