### PR TITLE
Stop over-writing the Token constant in specs

### DIFF
--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -6,10 +6,10 @@ describe Rouge::Formatters::HTMLLinewise do
 
   let(:options) { {} }
   let(:output) { subject.format(input_stream) }
-  Token = Rouge::Token
+  token = Rouge::Token
 
   describe 'a simple token stream' do
-    let(:input_stream) { [[Token['Name'], 'foo']] }
+    let(:input_stream) { [[token['Name'], 'foo']] }
 
     it 'formats' do
       assert { output == %(<div class="line-1"><span class="n">foo</span></div>) }
@@ -17,7 +17,7 @@ describe Rouge::Formatters::HTMLLinewise do
   end
 
   describe 'final newlines' do
-    let(:input_stream) { [[Token['Text'], "foo\n"], [Token['Name'], "bar\n"]] }
+    let(:input_stream) { [[token['Text'], "foo\n"], [token['Name'], "bar\n"]] }
 
     it 'formats' do
       assert { output == %(<div class="line-1">foo</div><div class="line-2"><span class="n">bar</span></div>) }
@@ -25,7 +25,7 @@ describe Rouge::Formatters::HTMLLinewise do
   end
 
   describe 'intermediate newlines' do
-    let(:input_stream) { [[Token['Name'], "foo\nbar"]] }
+    let(:input_stream) { [[token['Name'], "foo\nbar"]] }
 
     it 'formats' do
       assert { output == %(<div class="line-1"><span class="n">foo</span></div><div class="line-2"><span class="n">bar</span></div>) }

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -3,11 +3,11 @@
 describe Rouge::Formatters::HTML do
   let(:subject) { Rouge::Formatters::HTMLLegacy.new(options) }
   let(:options) { {} }
-  Token = Rouge::Token
+  token = Rouge::Token
 
   describe 'skipping the wrapper' do
     let(:subject) { Rouge::Formatters::HTML.new }
-    let(:output) { subject.format([[Token['Name'], 'foo']]) }
+    let(:output) { subject.format([[token['Name'], 'foo']]) }
     let(:options) { { :wrap => false } }
 
     it 'skips the wrapper' do
@@ -23,7 +23,7 @@ describe Rouge::Formatters::HTML do
     let(:options) { { :inline_theme => InlineTheme.new, :wrap => false } }
 
     let(:output) {
-      subject.format([[Token['Name'], 'foo']])
+      subject.format([[token['Name'], 'foo']])
     }
 
     it 'inlines styles given a theme' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ require 'wrong/adapters/minitest'
 
 Wrong.config[:color] = true
 
+Token = Rouge::Token
+
 Dir[File.expand_path('support/**/*.rb', File.dirname(__FILE__))].each {|f|
   require f
 }


### PR DESCRIPTION
This gets rid of a warning when running the specs