### PR TITLE
fix the perl POD lexer

### DIFF
--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -66,7 +66,7 @@ module Rouge
 
       state :root do
         rule /#.*?$/, Comment::Single
-        rule /^=[a-zA-Z0-9]+\s+.*?\n=cut/ms, Comment::Multiline
+        rule /^=[a-zA-Z0-9]+\s+.*?\n=cut/m, Comment::Multiline
         rule /(?:#{keywords.join('|')})\b/, Keyword
 
         rule /(format)(\s+)([a-zA-Z0-9_]+)(\s*)(=)(\s*\n)/ do

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -66,7 +66,7 @@ module Rouge
 
       state :root do
         rule /#.*?$/, Comment::Single
-        rule /^=[a-zA-Z0-9]+\s+.*?\n=cut/, Comment::Multiline
+        rule /^=[a-zA-Z0-9]+\s+.*?\n=cut/ms, Comment::Multiline
         rule /(?:#{keywords.join('|')})\b/, Keyword
 
         rule /(format)(\s+)([a-zA-Z0-9_]+)(\s*)(=)(\s*\n)/ do

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -213,4 +213,14 @@ for (
     print $_, "\n";
 }
 
+=head1 Single Quote Breaker
+
+That's all folks
+
+=cut
+
+sub foo {
+    "after the POD with the single quote, it's all still good"
+}
+
 


### PR DESCRIPTION
The Perl syntax highlighter was ignoring POD, and there was the especially perniscious issue single quotes in POD starting a highlighted string that continued until the next single quote in the code.

Perl POD looks like this

    =head1

    blah, blah, blah

    =cut

For that lexer regex to be able to match ^ to the start of a *line* it needs
the /m switch. I thought it would need an /s so that .* would match the intervening newlines, but apparently not.

A demonstration file:

    require 'rouge'
    
    source = <<EOL
    sub foo1 {
        "yakety yak"
    }
    
    =head1 Single Quote Breaker
    
    That's all folks
    
    =cut
    
    sub foo1 {
        "here we go, it's broken until that next single quote"
    }
    EOL
    
    formatter = Rouge::Formatters::HTML.new
    lexer = Rouge::Lexers::Perl.new
    print formatter.format(lexer.lex(source))
