### PR TITLE
JS: Fix template interpolation with the } in separate line

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -138,7 +138,6 @@ module Rouge
 
       state :root do
         rule /\A\s*#!.*?\n/m, Comment::Preproc, :statement
-        rule /\n/, Text, :statement
         rule %r((?<=\n)(?=\s|/|<!--)), Text, :expr_start
         mixin :comments_and_whitespace
         rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | ===

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -210,6 +210,13 @@ function* range(from, to)
 `$`;
 `$${1 + 2 + 3}`;
 
+`${
+  'multiline template'
+}`;
+`${
+  1 + 2
+}`;
+
 @(function(thing) { return thing; })
 class Person {
   @deprecate


### PR DESCRIPTION
Fixes #569. The following seems correctly highlighted:

```js
const foo = 'foo'
const multiline = `${
  foo
}`
function unrelated () {}
const bar = `${''
}\n`
const baz = `${
  1 + 2
} + ${
  2 + 3
}`
```

I believe the cause is the `rule /\n/, Text, :statement` rule in `:root`. The contents of `${}` is an expression, not a statement list; however, `:expr_start` did not behave as expected.