### PR TITLE
Use zero-width assertion to avoid overread

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -246,7 +246,7 @@ module Rouge
       state :template_string do
         rule /\${/, Punctuation, :template_string_expr
         rule /`/, Str::Double, :pop!
-        rule /(\\\\|\\[\$`]|[^\$`]|\$[^{])*/, Str::Double
+        rule /(\\\\|\\[\$`]|[^\$`]|\$(?!{))*/, Str::Double
       end
 
       state :template_string_expr do

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -204,8 +204,11 @@ function* range(from, to)
 `this is ${"sparta".toUpperCase()}`;
 
 // nasty string interpolation
-`this\n \` \${2} $` is\n ${"sparta".toUpperCase() + function() { return 4; } + "h"}`;
+`this\n \` \${2} $\` is\n ${"sparta".toUpperCase() + function() { return 4; } + "h"}`;
 `hello ${"${re}" + `curs${1}on`}`;
+
+`$`;
+`$${1 + 2 + 3}`;
 
 @(function(thing) { return thing; })
 class Person {


### PR DESCRIPTION
Fixes highlighting in:

```js
const a = `$${token}`
const b = `$`
// eof
```