### PR TITLE
Fix ruby dot quirks

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -164,6 +164,7 @@ module Rouge
         rule /0_?[0-7]+(?:_[0-7]+)*/, Num::Oct
         rule /0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*/, Num::Hex
         rule /0b[01]+(?:_[01]+)*/, Num::Bin
+        rule /\d+\.\d+(e[\+\-]?\d+)?/, Num::Float
         rule /[\d]+(?:_\d+)*/, Num::Integer
 
         # names

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -205,6 +205,10 @@ module Rouge
 
         mixin :has_heredocs
 
+        # `..` and `...` for ranges must have higher priority than `.`
+        # Otherwise, they will be parsed as :method_call
+        rule /\.{2,3}/, Operator, :expr_start
+
         rule /[A-Z][a-zA-Z0-9_]*/, Name::Constant, :method_call
         rule /(\.|::)(\s*)([a-z_]\w*[!?]?|[*%&^`~+-\/\[<>=])/ do
           groups Punctuation, Text, Name::Function
@@ -213,7 +217,7 @@ module Rouge
 
         rule /[a-zA-Z_]\w*[?!]/, Name, :expr_start
         rule /[a-zA-Z_]\w*/, Name, :method_call
-        rule /\*\*|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\.{1,3}/,
+        rule /\*\*|<<?|>>?|>=|<=|<=>|=~|={3}|!~|&&?|\|\||\./,
           Operator, :expr_start
         rule /[-+\/*%=<>&!^|~]=?/, Operator, :expr_start
         rule(/[?]/) { token Punctuation; push :ternary; push :expr_start }

--- a/spec/lexers/ruby_spec.rb
+++ b/spec/lexers/ruby_spec.rb
@@ -53,6 +53,22 @@ describe Rouge::Lexers::Ruby do
       end
     end
 
+    describe 'ranges' do
+      it 'handles .. as range operator' do
+        assert_tokens_equal "1..10",
+          ['Literal.Number.Integer', '1'],
+          ['Operator', '..'],
+          ['Literal.Number.Integer', '10']
+      end
+
+      it 'handles ... as range operator' do
+        assert_tokens_equal "'a'...'z'",
+          ['Literal.String.Single', "'a'"],
+          ['Operator', '...'],
+          ['Literal.String.Single', "'z'"]
+      end
+    end
+
     describe 'numerics' do
       it 'distinguishes Float from Integer' do
         assert_tokens_equal "2.3 + 5",

--- a/spec/lexers/ruby_spec.rb
+++ b/spec/lexers/ruby_spec.rb
@@ -52,6 +52,26 @@ describe Rouge::Lexers::Ruby do
         end
       end
     end
+
+    describe 'numerics' do
+      it 'distinguishes Float from Integer' do
+        assert_tokens_equal "2.3 + 5",
+          ['Literal.Number.Float', '2.3'],
+          ['Text', ' '],
+          ['Operator', '+'],
+          ['Text', ' '],
+          ['Literal.Number.Integer', '5']
+      end
+
+      it 'identifies Floats with exponent correctly' do
+        assert_tokens_equal "12.3e4",
+          ['Literal.Number.Float', '12.3e4']
+        assert_tokens_equal "5.67e-9",
+          ['Literal.Number.Float', '5.67e-9']
+        assert_tokens_equal "20.4e+8",
+          ['Literal.Number.Float', '20.4e+8']
+      end
+    end
   end
 
   describe 'guessing' do

--- a/spec/visual/samples/ruby
+++ b/spec/visual/samples/ruby
@@ -44,6 +44,19 @@ x.a / 1 # comment
 Foo::a / 3 + 4
 
 ########
+# The popular . :bow:
+########
+
+# It appears in Floats
+2.3
+
+# It appears in Range
+1..10
+
+# It can even appear thrice in a row!
+10...100
+
+########
 # method calls
 ########
 


### PR DESCRIPTION
For https://github.com/jneen/rouge/issues/375

This PR addresses the bugs around `.` for Ruby's lexer

- Correctly identifies floats
- Treat `..` and `...` of range as a single operator

Before fix:

<img width="324" alt="screen shot 2016-11-26 at 1 24 02 am" src="https://cloud.githubusercontent.com/assets/3772828/20629746/124a92a8-b368-11e6-967d-754c94ddf64b.png">

After fix:

<img width="324" alt="screen shot 2016-11-26 at 1 24 02 am" src="https://cloud.githubusercontent.com/assets/3772828/20632242/103244ac-b377-11e6-953f-94a5ac42dd41.png">
