### PR TITLE
split operators if they contain keyopts

### DIFF
--- a/lib/rouge/lexers/ocaml.rb
+++ b/lib/rouge/lexers/ocaml.rb
@@ -34,6 +34,37 @@ module Rouge
         @primitives ||= Set.new %w(unit int float bool string char list array)
       end
 
+      def self.gen_operator(a)
+        res = []
+        while not a.nil?
+
+          elem = :null
+          idx = a.length
+          for x in self.keyopts
+            i = a.index(x)
+            if not i.nil?
+              if i < idx || (i == idx and (x.length > elem.length))
+                elem = x
+                idx = i
+              end
+            end
+          end
+
+          if not elem.nil?
+            if idx > 0
+              res = res + [a[0..idx-1]]
+            end
+            res = res + [a[idx..idx+elem.length-1]]
+            a = a[idx + elem.length..a.length]
+          else
+            res = res + [a]
+            break
+          end
+        end
+
+        return res
+      end
+
       operator = %r([\[\];,{}_()!$%&*+./:<=>?@^|~#-]+)
       id = /[a-z][\w']*/i
       upper_id = /[A-Z][\w']*/
@@ -59,11 +90,12 @@ module Rouge
         end
 
         rule operator do |m|
-          match = m[0]
-          if self.class.keyopts.include? match
-            token Punctuation
-          else
-            token Operator
+          for x in self.class.gen_operator(m[0])
+            if self.class.keyopts.include? x
+               token Punctuation , x
+            else
+               token Operator , x
+            end
           end
         end
 

--- a/spec/visual/samples/ocaml
+++ b/spec/visual/samples/ocaml
@@ -1232,3 +1232,11 @@ let kprintf = ksprintf;;
 let sprintf fmt = ksprintf (fun s -> s) fmt;;
 
 at_exit print_flush;;
+
+
+id ~a:4;;
+id ~a:(4) ;;
+id ~a: (4);;
+
+(fun a ->(a))
+


### PR DESCRIPTION
This should address #580. By default, the lexer parses whole strings of tokens and does a comparison to see if the operator is in a list of "punctuation operators". This patch replaces that equality check and splits up the operator if it contains a punctuation operator.

@gaborigloi should check this to see if this is the right behavior.

I don't really like the code very much. I had hoped to issue tokens directly from the `gen_operator` function, but I was getting ruby errors. Inlining the function seems less than ideal. There is probably a way to do it with regular expressions, and there is probably a way to make it more efficient by avoiding duplicate lookups.