### PR TITLE
Fix unescaped at-sign in regex

### DIFF
--- a/lib/rouge/lexers/abap.rb
+++ b/lib/rouge/lexers/abap.rb
@@ -217,13 +217,13 @@ module Rouge
 
         # operators
         rule %r((->|->>|=>)), Operator
-        rule %r([-\*\+%/~=&\?<>!#@\^]+), Operator
+        rule %r([-\*\+%/~=&\?<>!#\@\^]+), Operator
 
       end
 
       state :operators do
         rule %r((->|->>|=>)), Operator
-        rule %r([-\*\+%/~=&\?<>!#@\^]+), Operator
+        rule %r([-\*\+%/~=&\?<>!#\@\^]+), Operator
       end
 
       state :single_string do


### PR DESCRIPTION
This single missing character stops the library from working on Ruby
1.9.