### PR TITLE
Rust: recognize range operator and type variables

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -86,7 +86,7 @@ module Rouge
         rule %r([=-]>), Keyword
         rule %r(<->), Keyword
         rule /[()\[\]{}|,:;]/, Punctuation
-        rule /[*!@~&+%^<>=-\?]/, Operator
+        rule /[*!@~&+%^<>=-\?]|\.{2,3}/, Operator
 
         rule /([.]\s*)?#{id}(?=\s*[(])/m, Name::Function
         rule /[.]\s*#{id}/, Name::Property
@@ -98,6 +98,7 @@ module Rouge
         rule /\bmacro_rules!/, Name::Decorator, :macro_rules
         rule /#{id}!/, Name::Decorator, :macro
 
+        rule /'#{id}/, Name::Variable
         rule /#{id}/ do |m|
           name = m[0]
           if self.class.builtins.include? name

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -1,11 +1,11 @@
 fn f() {
-    let a = ~"hello";
+    let a = String::new("hello");
     let b: &str = a;
     io::println(b);
 }
 
 fn g() {
-    let c = ~"world";
+    let c = String::new("world");
     let d: &str;
     d = c;
     io::println(d);
@@ -37,14 +37,6 @@ impl<A> &[A]: iterable<A> {
     }
 }
 
-impl<A> ~[A]: iterable<A> {
-    fn iterate(f: fn(x: &A) -> bool) {
-        for vec::each(self) |e| {
-            if !f(e) { break; }
-        }
-    }
-}
-
 fn length<A, T: iterable<A>>(x: T) -> uint {
     let mut len = 0;
     for x.iterate() |_y| { len += 1 }
@@ -52,7 +44,7 @@ fn length<A, T: iterable<A>>(x: T) -> uint {
 }
 
 fn main() {
-    let x = ~[0,1,2,3];
+    let x = vec![0,1,2,3];
     // Call a method
     for x.iterate() |y| { assert x[*y] == *y; }
     // Call a parameterized function
@@ -230,7 +222,7 @@ mod test_distinguish_syntax_ext {
     extern mod std;
 
     fn f() {
-        fmt!("test%s", ~"s");
+        fmt!("test%s", String::new("s"));
         #[attr = "val"]
         fn g() { }
     }

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -61,6 +61,15 @@ fn main() {
     assert length::<int, &[int]>(z) == vec::len(z);
 }
 
+fn<'a> pointer(&'a u32) {}
+
+fn range() {
+    let a = 1..2;
+    let b = 1..;
+    let c = ..2;
+    let d = ..;
+    let e = 5...6;
+}
 
 #[attr1 = "val"];
 #[attr2 = "val"];


### PR DESCRIPTION
Right now they get highlighted as errors.