### PR TITLE
Update JavaScript token set to ES2017, TypeScript to 2.1

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -97,22 +97,26 @@ module Rouge
 
       def self.keywords
         @keywords ||= Set.new %w(
-          for in while do break return continue switch case default
+          for in of while do break return continue switch case default
           if else throw try catch finally new delete typeof instanceof
-          void this yield
+          void this yield import export from as async super this
         )
       end
 
       def self.declarations
-        @declarations ||= Set.new %w(var let with function)
+        @declarations ||= Set.new %w(
+          var let const with function class
+          extends constructor get set
+        )
       end
 
       def self.reserved
         @reserved ||= Set.new %w(
-          abstract boolean byte char class const debugger double enum
-          export extends final float goto implements import int interface
+          abstract boolean byte char debugger double enum
+          final float goto implements int interface
           long native package private protected public short static
-          super synchronized throws transient volatile
+          synchronized throws transient volatile
+          eval arguments await
         )
       end
 
@@ -125,8 +129,13 @@ module Rouge
           Array Boolean Date Error Function Math netscape
           Number Object Packages RegExp String sun decodeURI
           decodeURIComponent encodeURI encodeURIComponent
-          Error eval isFinite isNaN parseFloat parseInt document this
-          window
+          Error eval isFinite isNaN parseFloat parseInt
+          document window navigator self global
+          Promise Set Map WeakSet WeakMap Symbol Proxy Reflect
+          Int8Array Uint8Array Uint8ClampedArray
+          Int16Array Uint16Array Uint16ClampedArray
+          Int32Array Uint32Array Uint32ClampedArray
+          Float32Array Float64Array DataView ArrayBuffer
         )
       end
 

--- a/lib/rouge/lexers/typescript.rb
+++ b/lib/rouge/lexers/typescript.rb
@@ -17,28 +17,27 @@ module Rouge
 
       def self.keywords
         @keywords ||= super + Set.new(%w(
-          import export from as is
-          namespace new static private protected public
-          super async await extends implements readonly
+          is namespace static private protected public
+          implements readonly
         ))
       end
 
       def self.declarations
         @declarations ||= super + Set.new(%w(
-          const type constructor abstract
+          type abstract
         ))
       end
 
       def self.reserved
         @reserved ||= super + Set.new(%w(
-          string any number namespace module
-          declare default interface
+          string any void number namespace module
+          declare default interface keyof
         ))
       end
 
       def self.builtins
         @builtins ||= super + %w(
-          Promise Set Map WeakSet WeakMap Symbol
+          Pick Partial Readonly Record
         )
       end
     end

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -228,3 +228,26 @@ class Person {
   @deprecate('We stopped facepalming', { url: 'http://knowyourmeme.com/memes/facepalm' })
   facepalmHarder() {}
 }
+
+// ES6 module
+import * as foo from 'foo'
+import { bar as baz } from 'bar'
+export * from 'baz'
+export function hoge() {}
+export class fuga extends baz {
+  constructor () {
+    super()
+  }
+  async doit (stuff) {
+    await stuff()
+    this.dont(stuff)
+  }
+  dont (stuff) {
+    return arguments.length
+  }
+}
+eval('false')
+global.foo = {
+  * [Symbol.iterator] () { return }
+}
+for (const x of global.foo) {}

--- a/spec/visual/samples/typescript
+++ b/spec/visual/samples/typescript
@@ -190,3 +190,11 @@ import { Component } from '@angular/core';
   template: '<h1>My First Angular App</h1>'
 })
 export class AppComponent { }
+
+// Mapped types
+declare module "foo" {
+  export type IFooPartial = Partial<IFoo>
+  export interface IFooPartial2 {
+    [K in keyof IFoo]?: IFoo[K]
+  }
+}


### PR DESCRIPTION
This also removes from typescript's token sets the tokens that are in
ES2017. The typescript builtins are used for generating mapped types.

global is actually stage-3 in JavaScript, but is very likely to reach
stage-4 in time for ES2017. At any rate, it is already a builtin in
Node.