### PR TITLE
[JSON] Makes the sign for exponents in integers and floats optional

### DIFF
--- a/lib/rouge/lexers/json.rb
+++ b/lib/rouge/lexers/json.rb
@@ -14,8 +14,8 @@ module Rouge
         rule /"/, Str::Double, :string
         rule /(?:true|false|null)\b/, Keyword::Constant
         rule /[{},:\[\]]/, Punctuation
-        rule /-?(?:0|[1-9]\d*)\.\d+(?:e[+-]\d+)?/i, Num::Float
-        rule /-?(?:0|[1-9]\d*)(?:e[+-]\d+)?/i, Num::Integer
+        rule /-?(?:0|[1-9]\d*)\.\d+(?:e[+-]?\d+)?/i, Num::Float
+        rule /-?(?:0|[1-9]\d*)(?:e[+-]?\d+)?/i, Num::Integer
       end
 
       state :string do


### PR DESCRIPTION
This PR aims to improve compliance with JSON.org (and thus, [RFC7159](https://tools.ietf.org/html/rfc7159#section-6)).
This states that a JSON parsable number has to have the following format:
`number = [ minus ] int [ frac ] [ exp ]` with `exp = e [ minus / plus ] 1*DIGIT`
As such, the sign of the exponent in floats and integers is optional, resulting in the following interpretations also being valid JSON notation:

```json
{
  "float_with_positive_exponent":4.2e1,
  "integer_with_positive_exponent":9e3
}
```

Currently this renders invalid due to a missing `+` or `-`.