### PR TITLE
Terminal formatting fix

### DIFF
--- a/lib/rouge/formatters/terminal256.rb
+++ b/lib/rouge/formatters/terminal256.rb
@@ -17,7 +17,7 @@ module Rouge
         tokens.each do |tok, val|
           escape = escape_sequence(tok)
           yield escape.style_string
-          yield val.gsub("\n", "\n#{escape.style_string}")
+          yield val.gsub("\n", "#{escape.reset_string}\n#{escape.style_string}")
           yield escape.reset_string
         end
       end

--- a/spec/formatters/html_linewise_spec.rb
+++ b/spec/formatters/html_linewise_spec.rb
@@ -6,7 +6,6 @@ describe Rouge::Formatters::HTMLLinewise do
 
   let(:options) { {} }
   let(:output) { subject.format(input_stream) }
-  Token = Rouge::Token
 
   describe 'a simple token stream' do
     let(:input_stream) { [[Token['Name'], 'foo']] }

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -3,7 +3,6 @@
 describe Rouge::Formatters::HTML do
   let(:subject) { Rouge::Formatters::HTMLLegacy.new(options) }
   let(:options) { {} }
-  Token = Rouge::Token
 
   describe 'skipping the wrapper' do
     let(:subject) { Rouge::Formatters::HTML.new }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ require 'wrong/adapters/minitest'
 
 Wrong.config[:color] = true
 
+Token = Rouge::Token
+
 Dir[File.expand_path('support/**/*.rb', File.dirname(__FILE__))].each {|f|
   require f
 }


### PR DESCRIPTION
I'm working on adding syntax highlighting to [byebug](https://github.com/deivid-rodriguez/byebug) and I tried rouge for the code snippets that are displayed during a debugging session. It works great but when I further process the highlighted code for adding line numbers and a current line marker, these new elements get incorrect styles.

This commit should fix it and it could be seen as a follow up to 570d420788d59028b5c52f743000ccb8f6fb6ae2. I also added an extra change to the PR, just to get the tests passing without warnings.

Before:

![before](https://cloud.githubusercontent.com/assets/2887858/21578270/f5e07cf8-cf60-11e6-969b-6a0ebd9f978d.png)

After:

![after](https://cloud.githubusercontent.com/assets/2887858/21578261/6933f046-cf60-11e6-97c4-18d5b882f3e9.png)
