### PR TITLE
Fix coffeescript multiline comments

### DIFF
--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -42,7 +42,7 @@ module Rouge
 
       state :comments_and_whitespace do
         rule /\s+/m, Text
-        rule /###.*?###/m, Comment::Multiline
+        rule /###\s*\n.*?###/m, Comment::Multiline
         rule /#.*$/, Comment::Single
       end
 

--- a/spec/visual/samples/coffeescript
+++ b/spec/visual/samples/coffeescript
@@ -2,6 +2,9 @@
 a multiline comment
 ###
 
+# The following line of hashes does not start a multiline comment
+#################
+
 { property         : 1 }
 
 # these shouldn't be highlighted as constants, since this is


### PR DESCRIPTION
Fixes #599 

Coffeescript allows multiline comments, starting with three hashes
on one line, text, and three closing hashes on the last line.
This adds an optional whitespace plus an explicit newline in the
regex to ensure the starting comment line only matches three hashes.

**Before:**

![screen shot 2017-01-04 at 4 04 36 pm](https://cloud.githubusercontent.com/assets/2394772/21660994/8e3b8f90-d297-11e6-8c32-7fe03de3415a.png)

**After:**

![screen shot 2017-01-04 at 4 04 11 pm](https://cloud.githubusercontent.com/assets/2394772/21660997/8fdacdb6-d297-11e6-846e-88d7acc86144.png)