### PR TITLE
Add HyLang support

### DIFF
--- a/lib/rouge/demos/hylang
+++ b/lib/rouge/demos/hylang
@@ -1,0 +1,10 @@
+(defn simple-conversation []
+   (print "Hello!  I'd like to get to know you.  Tell me about yourself!")
+   (setv name (input "What is your name? "))
+   (let [age (input "What is your age? ")]
+     (if (and age
+              name)
+       (print (+ "Hello " name "!  I see you are "
+                 age " years old.")))))
+
+(simple-conversation)

--- a/lib/rouge/lexers/hylang.rb
+++ b/lib/rouge/lexers/hylang.rb
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class HyLang < RegexLexer
+      title "HyLang"
+      desc "The HyLang programming language (hylang.org)"
+
+      tag 'hylang'
+      aliases 'hy'
+
+      filenames '*.hy'
+
+      mimetypes 'text/x-hy', 'application/x-hy'
+
+      def self.keywords
+        @keywords ||= Set.new %w(
+          False None True and as assert break class continue def
+          del elif else except finally for from global if import
+          in is lambda nonlocal not or pass raise return try
+        )
+      end
+
+      def self.builtins
+        @builtins ||= Set.new %w(
+          != % %= & &= * ** **= *= *map
+          + += , - -= -> ->> . / //
+          //= /= < << <<= <= = > >= >>
+          >>= @ @= ^ ^= accumulate apply as-> assoc butlast
+          calling-module-name car cdr chain coll? combinations comp complement compress cond
+          cons cons? constantly count cut cycle dec defclass defmacro defmacro!
+          defmacro/g! defmain defn defreader dict-comp disassemble dispatch-reader-macro distinct do doto
+          drop drop-last drop-while empty? eval eval-and-compile eval-when-compile even? every? filter
+          first flatten float? fn for* fraction genexpr gensym get group-by
+          identity if* if-not if-python2 inc input instance? integer integer-char? integer?
+          interleave interpose islice iterable? iterate iterator? juxt keyword keyword? last
+          let lif lif-not list* list-comp macro-error macroexpand macroexpand-1 map merge-with
+          multicombinations name neg? none? not-in not? nth numeric? odd? partition
+          permutations pos? product quasiquote quote range read read-str reduce remove
+          repeat repeatedly require rest second set-comp setv some string string?
+          symbol? take take-nth take-while tee unless unquote unquote-splicing when with*
+          with-decorator with-gensyms xor yield-from zero? zip zip-longest | |= ~
+        )
+      end
+
+      identifier = %r([\w!$%*+,<=>?/.-]+)
+      keyword = %r([\w!\#$%*+,<=>?/.-]+)
+
+      def name_token(name)
+        return Keyword if self.class.keywords.include?(name)
+        return Name::Builtin if self.class.builtins.include?(name)
+        nil
+      end
+
+      state :root do
+        rule /;.*?$/, Comment::Single
+        rule /\s+/m, Text::Whitespace
+
+        rule /-?\d+\.\d+/, Num::Float
+        rule /-?\d+/, Num::Integer
+        rule /0x-?[0-9a-fA-F]+/, Num::Hex
+
+        rule /"(\\.|[^"])*"/, Str
+        rule /'#{keyword}/, Str::Symbol
+        rule /::?#{keyword}/, Name::Constant
+        rule /\\(.|[a-z]+)/i, Str::Char
+
+
+        rule /~@|[`\'#^~&@]/, Operator
+
+        rule /(\()(\s*)(#{identifier})/m do |m|
+          token Punctuation, m[1]
+          token Text::Whitespace, m[2]
+          token(name_token(m[3]) || Name::Function, m[3])
+        end
+
+        rule identifier do |m|
+          token name_token(m[0]) || Name
+        end
+
+        # vectors
+        rule /[\[\]]/, Punctuation
+
+        # maps
+        rule /[{}]/, Punctuation
+
+        # parentheses
+        rule /[()]/, Punctuation
+      end
+    end
+  end
+end
+

--- a/spec/lexers/hylang_spec.rb
+++ b/spec/lexers/hylang_spec.rb
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::HyLang do
+  let(:subject) { Rouge::Lexers::HyLang.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.hy'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-hy'
+      assert_guess :mimetype => 'application/x-hy'
+    end
+  end
+end

--- a/spec/visual/samples/hylang
+++ b/spec/visual/samples/hylang
@@ -1,0 +1,72 @@
+#!/usr/bin/env hy
+
+(import hy.core)
+
+
+(defn hyghlight-names []
+  (-> (hy.core.reserved.names)
+      (sorted)))
+
+
+(defn hyghlight-keywords []
+  (sorted hy.core.reserved.keyword.kwlist))
+
+
+(defn hyghlight-builtins []
+  (sorted
+   (- (hy.core.reserved.names)
+      (frozenset hy.core.reserved.keyword.kwlist))))
+
+
+(defmacro replace-line [spaces line-format end-of-line keywords]
+  `(+ line
+      (.join ~end-of-line
+             (list-comp
+              (.format ~line-format
+                       :space (* " " ~spaces)
+                       :line (.join " " keyword-line))
+              [keyword-line (partition ~keywords 10)]))
+      "\n"))
+
+(defn generate-highlight-js-file []
+  (defn replace-highlight-js-keywords [line]
+    (cond
+     [(in "// keywords" line) (replace-line 6
+                                            "{space}'{line} '"
+                                            " +\n"
+                                            (hyghlight-names))]
+     [True line]))
+
+  (with [f (open "templates/highlight_js/hy.js")]
+        (.join ""
+               (list-comp (replace-highlight-js-keywords line)
+                          [line (.readlines f)]))))
+
+
+(defn generate-rouge-file []
+  (defn replace-rouge-keywords [line]
+    (cond
+     [(in "@keywords" line) (replace-line 10
+                                          "{space}{line}"
+                                          "\n"
+                                          (hyghlight-keywords))]
+     [(in "@builtins" line) (replace-line 10
+                                          "{space}{line}"
+                                          "\n"
+                                          (hyghlight-builtins))]
+     [True line]))
+
+  (with [f (open "templates/rouge/hylang.rb")]
+        (.join ""
+               (list-comp (replace-rouge-keywords line)
+                          [line (.readlines f)]))))
+
+
+(defmain [&rest args]
+  (let [highlight-library (second args)]
+    (print (cond
+            [(= highlight-library "highlight.js")
+             (generate-highlight-js-file)]
+            [(= highlight-library "rouge")
+             (generate-rouge-file)]
+            [True "Usage: hy hyghlight.hy [highlight.js | rouge]"]))))


### PR DESCRIPTION
Hi @jneen,

This PR adds [HyLang](http://hylang.org/) support.
It is based on Clojure lexer source code.

The lexer itself is autogenerated using [hyghlight project](https://github.com/hylang/hyghlight/pull/2).

Thank you.