### PR TITLE
Wrap tokens with div.highlight as Pygments does

### DIFF
--- a/lib/rouge/formatters/html_pygments.rb
+++ b/lib/rouge/formatters/html_pygments.rb
@@ -7,9 +7,9 @@ module Rouge
       end
 
       def stream(tokens, &b)
-        yield %(<pre class="#{@css_class}"><code>)
+        yield %(<div class="highlight"><pre class="#{@css_class}"><code>)
         @inner.stream(tokens, &b)
-        yield "</code></pre>"
+        yield "</code></pre></div>"
       end
     end
   end

--- a/spec/formatters/html_pygments_spec.rb
+++ b/spec/formatters/html_pygments_spec.rb
@@ -1,0 +1,15 @@
+describe Rouge::Formatters::HTMLPygments do
+  let(:formatter) { Rouge::Formatters::HTML.new }
+  let(:source) { 'echo "Hello World"' }
+  let(:lexer) { Rouge::Lexers::Shell.new }
+  let(:subject) { Rouge::Formatters::HTMLPygments.new(formatter, lexer.tag) }
+  let(:output) { subject.format(lexer.lex(source)) }
+
+  it 'wrap with div.highlight' do
+    assert { output =~ /\A<div class="highlight">.+<\/div>\Z/ }
+  end
+
+  it 'contain pre with class name "shell"' do
+    assert { output =~ /<pre class="shell">/ }
+  end
+end


### PR DESCRIPTION
`Formatters::HTMLPygments` does not wrap tokens with div element though described in document just like below.

> wraps the given formatter with div wrappers generally expected by stylesheets designed for Pygments.

This pull request wraps tokens with div.highlight. This behavior is Pygments HTML Formatters' default.

http://pygments.org/docs/quickstart/#example