### PR TITLE
Add lexer for TSX (TypeScript React) files

### DIFF
--- a/lib/rouge/demos/tsx
+++ b/lib/rouge/demos/tsx
@@ -1,0 +1,17 @@
+class HelloWorld extends React.Component<{ props: string; }, undefined> {
+  render() {
+    return (
+      <p>
+        Hello, <input type="text" placeholder="Your name here" />!
+        It is {this.props.date.toTimeString()}
+      </p>
+    );
+  }
+}
+
+setInterval(function() {
+  ReactDOM.render(
+    <HelloWorld date={new Date()} />,
+    document.getElementById('example')
+  );
+}, 500);

--- a/lib/rouge/lexers/tsx.rb
+++ b/lib/rouge/lexers/tsx.rb
@@ -1,0 +1,101 @@
+module Rouge
+  module Lexers
+    load_lexer 'typescript.rb'
+
+    class TSX < Typescript
+      desc 'tsx'
+      tag 'tsx'
+      aliases 'tsx'
+      filenames '*.tsx'
+
+      mimetypes 'text/x-tsx', 'application/x-tsx'
+
+      id = Typescript.id_regex
+
+      def start_embed!
+        @embed ||= TSX.new(options)
+        @embed.reset!
+        @embed.push(:expr_start)
+        push :tsx_embed_root
+      end
+
+      def tag_token(name)
+        name[0] =~ /\p{Lower}/ ? Name::Tag : Name::Class
+      end
+
+      start { @html = HTML.new(options) }
+
+      state :tsx_tags do
+        rule /</, Punctuation, :tsx_element
+      end
+
+      state :tsx_internal do
+        rule %r(</) do
+          token Punctuation
+          goto :tsx_end_tag
+        end
+
+        rule /{/ do
+          token Str::Interpol
+          start_embed!
+        end
+
+        rule /[^<>{]+/ do
+          delegate @html
+        end
+
+        mixin :tsx_tags
+      end
+
+      prepend :expr_start do
+        mixin :tsx_tags
+      end
+
+      state :tsx_tag do
+        mixin :comments_and_whitespace
+        rule /#{id}/ do |m|
+          token tag_token(m[0])
+        end
+
+        rule /[.]/, Punctuation
+      end
+
+      state :tsx_end_tag do
+        mixin :tsx_tag
+        rule />/, Punctuation, :pop!
+      end
+
+      state :tsx_element do
+        rule /#{id}=/, Name::Attribute, :tsx_attribute
+        mixin :tsx_tag
+        rule />/ do token Punctuation; goto :tsx_internal end
+        rule %r(/>), Punctuation, :pop!
+      end
+
+      state :tsx_attribute do
+        rule /"(\\[\\"]|[^"])*"/, Str::Double, :pop!
+        rule /'(\\[\\']|[^'])*'/, Str::Single, :pop!
+        rule /{/ do
+          token Str::Interpol
+          pop!
+          start_embed!
+        end
+      end
+
+      state :tsx_embed_root do
+        rule /[.][.][.]/, Punctuation
+        rule /}/, Str::Interpol, :pop!
+        mixin :tsx_embed
+      end
+
+      state :tsx_embed do
+        rule /{/ do delegate @embed; push :tsx_embed end
+        rule /}/ do delegate @embed; pop! end
+        rule /[^{}]+/ do
+          delegate @embed
+        end
+      end
+    end
+  end
+end
+

--- a/spec/lexers/tsx_spec.rb
+++ b/spec/lexers/tsx_spec.rb
@@ -1,0 +1,17 @@
+describe Rouge::Lexers::TSX do
+  let(:subject) { Rouge::Lexers::TSX.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.tsx'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-tsx'
+      assert_guess :mimetype => 'application/x-tsx'
+    end
+  end
+end
+

--- a/spec/visual/samples/tsx
+++ b/spec/visual/samples/tsx
@@ -1,0 +1,97 @@
+let myDivElement = <div className="foo" />;
+ReactDOM.render(myDivElement, document.getElementById('example'));
+
+
+
+let MyComponent = React.createClass({/*...*/});
+let myElement = <MyComponent someProperty={true} />;
+ReactDOM.render(myElement, document.getElementById('example'));
+
+let myElement = <MyComponent someProperty={{a:true}.a} />;
+let myElement = <MyComponent someProperty={function() {
+  let x = { a: true };
+  return x.a;
+}} />
+
+thing.otherThing<MyComponent.property // comment - this is comparison
+let myElement = <MyComponent thing={thing.otherThing>2}>
+  hello, world!
+</MyComponent>
+
+let content = <Container>{window.isLoggedIn ? <Nav /> : <Login />}</Container>;
+
+// These two are equivalent in TSX for disabling a button
+<input type="button" disabled />;
+<input type="button" disabled={true} />;
+
+// And these two are equivalent in TSX for not disabling a button
+<input type="button" />;
+<input type="button" disabled={false} />;
+
+let App = (
+  <Form>
+    <Form.Row>
+      <Form.Label />
+      <Form.Input />
+    </Form.Row>
+  </Form>
+);
+
+let content = (
+  <Nav>
+    {/* child comment, put {} around */}
+    a slash-star that isn't a comment because this is html: /*
+    <Person
+      /* multi
+         line
+         comment */
+      name={window.isLoggedIn ? window.name : ''} // end of line comment
+    />
+  </Nav>
+);
+
+let App = (
+  <Form>
+    <FormRow>
+      <FormLabel />
+      <FormInput />
+    </FormRow>
+  </Form>
+);
+
+let thing = <A b={function() { let c = <D e={true}>&quot;</D>; }()}/>
+
+export interface LikeButtonState {
+  liked: boolean;
+}
+
+class LikeButton extends React.Component<{ liked: boolean }, LikeButtonState> {
+  constructor(props: { liked: boolean }) {
+    super(props);
+
+    this.state = {
+      liked: this.props.liked
+    };
+
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    this.setState({ liked: !this.state.liked });
+  }
+
+  render() {
+    const text = this.state.liked ? 'liked' : 'haven\'t liked';
+
+    return (
+      <div onClick={this.handleClick}>
+        You {text} this. Click to toggle.
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(
+  <LikeButton liked={false} />,
+  document.getElementById('example')
+);


### PR DESCRIPTION
I know the README says to avoid copying & pasting other lexers, but in this case I think its acceptable. The TSX and JSX files are nearly identical, except TSX is an extension of TypeScript where JSX is an extension of JavaScript. The extension of both languages are identical however.

Resolves #516