### PR TITLE
Fix handling of backtick character for PowerShell scripts

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -91,6 +91,11 @@ module Rouge
         rule /\bcase\b/, Keyword, :case
         rule /\b(#{BUILTINS})\s*\b(?!\.)/i, Name::Builtin
       end
+
+      prepend :interp do
+        rule /`./, Str::Escape
+        rule /`$/, Str::Escape # line continuation
+      end
     end
   end
 end


### PR DESCRIPTION
Backtick is an escape and line-continuation character in PowerShell.

Current behaviour:
![rouge_backtick_old](https://cloud.githubusercontent.com/assets/22765233/24260882/1d0975ec-0fed-11e7-9005-121f73cbf3d7.png)

Updated behaviour:
![rouge_backtick_new](https://cloud.githubusercontent.com/assets/22765233/24260903/279a9914-0fed-11e7-86d8-850ba4059f1b.png)
