### PR TITLE
Add hidden doc lines for Rust

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -58,17 +58,18 @@ module Rouge
         mixin :whitespace
         rule /\s+/, Text
         rule /#\[/ do
-          token Comment::Preproc; push :attribute
+          token Name::Decorator; push :attribute
         end
         rule(//) { pop! }
+        rule /#\s[^\n]*/, Comment::Preproc
       end
 
       state :attribute do
         mixin :whitespace
         mixin :has_literals
-        rule /[(,)=]/, Comment::Preproc
-        rule /\]/, Comment::Preproc, :pop!
-        rule id, Comment::Preproc
+        rule /[(,)=]/, Name::Decorator
+        rule /\]/, Name::Decorator, :pop!
+        rule id, Name::Decorator
       end
 
       state :whitespace do

--- a/spec/visual/samples/rust
+++ b/spec/visual/samples/rust
@@ -377,3 +377,8 @@ enum HTMLFragment {
     tag(~str, ~[HTMLFragment]),
     text(~str),
 }
+
+// Some hidden lines by starting with hash
+# extern crate core;
+# use core::str;
+# let x = 5;


### PR DESCRIPTION
This is a common syntax in Rust's documentation examples:

```rust
# extern crate foo;
# use foo::Bar;
let bar = Bar::new();
```

The intention is that `rustdoc` will hide any lines starting with `# `, but they are there so that the example can compile when running `rustdoc --test`.