### PR TITLE
Prevent html_table from outputting a line-feed after the </table> tag

### DIFF
--- a/lib/rouge/formatters/html_table.rb
+++ b/lib/rouge/formatters/html_table.rb
@@ -54,7 +54,7 @@ module Rouge
         yield formatted
         yield '</pre></td>'
 
-        yield "</tr></tbody></table>\n"
+        yield "</tr></tbody></table>"
       end
     end
   end


### PR DESCRIPTION
Prevents `HTMLTable` formatter from outputting a line-feed after the `</table>` closing tag.

Fixes #658