### PR TITLE
Replace backslash with backtick as escape character for PowerShell

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -81,6 +81,42 @@ module Rouge
         swmi tee trcm type wget where wjb write \% \?
       ).join('|')
 
+      # Override from Shell
+      state :interp do
+        rule /`$/, Str::Escape # line continuation
+        rule /`./, Str::Escape
+        rule /\$\(\(/, Keyword, :math
+        rule /\$\(/, Keyword, :paren
+        rule /\${#?/, Keyword, :curly
+        rule /\$#?(\w+|.)/, Name::Variable
+      end
+
+      # Override from Shell
+      state :double_quotes do
+        # NB: "abc$" is literally the string abc$.
+        # Here we prevent :interp from interpreting $" as a variable.
+        rule /(?:\$#?)?"/, Str::Double, :pop!
+        mixin :interp
+        rule /[^"`$]+/, Str::Double
+      end
+
+      # Override from Shell
+      state :data do
+        rule /\s+/, Text
+        rule /\$?"/, Str::Double, :double_quotes
+        rule /\$'/, Str::Single, :ansi_string
+
+        rule /'/, Str::Single, :single_quotes
+
+        rule /\*/, Keyword
+
+        rule /;/, Text
+        rule /[^=\*\s{}()$"'`\\<]+/, Text
+        rule /\d+(?= |\Z)/, Num
+        rule /</, Text
+        mixin :interp
+      end
+
       prepend :basic do
         rule %r(<#[\s,\S]*?#>)m, Comment::Multiline
         rule /#.*$/, Comment::Single

--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -111,7 +111,7 @@ module Rouge
         rule /\*/, Keyword
 
         rule /;/, Text
-        rule /[^=\*\s{}()$"'`\\<]+/, Text
+        rule /[^=\*\s{}()$"'`<]+/, Text
         rule /\d+(?= |\Z)/, Num
         rule /</, Text
         mixin :interp


### PR DESCRIPTION
This PR fixes the incorrect handling of escape characters in the PowerShell lexer as described in #640. This replaces #639: that PR added the backtick as an escape character, whereas this combined PR adds the backtick and also removes the backslash as an escape character.