### PR TITLE
Update Fortran lexer to Fortran 2008

### DIFF
--- a/lib/rouge/lexers/fortran.rb
+++ b/lib/rouge/lexers/fortran.rb
@@ -7,11 +7,11 @@ module Rouge
   module Lexers
     class Fortran < RegexLexer
       title "Fortran"
-      desc "Fortran 95 Programming Language"
+      desc "Fortran 2008 (free-form)"
 
       tag 'fortran'
-      filenames '*.f90', '*.f95',
-                '*.F90', '*.F95'
+      filenames '*.f90', '*.f95', '*.f03', '*.f08',
+                '*.F90', '*.F95', '*.F03', '*.F08'
       mimetypes 'text/x-fortran'
 
       name = /[A-Z][_A-Z0-9]*/i
@@ -21,40 +21,64 @@ module Rouge
       def self.keywords
         # Fortran allows to omit whitespace between certain keywords...
         @keywords ||= Set.new %w(
-          allocatable allocate assignment backspace block blockdata call case
-          close common contains continue cycle data deallocate default
-          dimension do elemental else elseif elsewhere end endblockdata enddo
-          endfile endforall endfunction endif endinterface endmodule endprogram
-          endselect endsubroutine endtype endwhere entry equivalence exit
-          external forall format function go goto if implicit in include inout
-          inquire intent interface intrinsic module namelist none nullify only
-          open operator optional out parameter pointer print private procedure
-          program public pure read recursive result return rewind save select
-          selectcase sequence stop subroutine target then to type use where
-          while write
+          abstract all allocatable allocate assign assignment asynchronous
+          backspace bind block blockdata close common concurrent contiguous call
+          case class codimension contains continue cycle data deallocate
+          deferred dimension do elemental else elseif elsewhere end endblock
+          endblockdata enddo endenum endfile endforall endfunction endif
+          endinterface endmodule endprogram endselect endsubmodule endsubroutine
+          endtype endwhere endwhile entry enum enumerator equivalence error exit
+          external final flush forall format function generic go goto if
+          implicit import in include inout inquire intent interface intrinsic is
+          module namelist non_overridable none nopass nullify only open operator
+          optional out parameter pass pause pointer print private procedure
+          program protected public pure read recursive result return rewind save
+          select selectcase sequence stop submodule subroutine target then to
+          type use value volatile wait where while write
         )
       end
 
       def self.types
+        # There is a separate rule for "double precision" (two words) below
         @types ||= Set.new %w(
-          character complex double precision doubleprecision integer logical real
+          character complex doubleprecision integer logical real
         )
       end
 
       def self.intrinsics
         @intrinsics ||= Set.new %w(
-          abs achar acos adjustl adjustr aimag aint all allocated anint any
-          asin associated atan atan2 bit_size btest ceiling char cmplx conjg
-          cos cosh count cpu_time cshift date_and_time dble digits dim
-          dot_product dprod eoshift epsilon exp exponent floor fraction huge
-          iachar iand ibclr ibits ibset ichar ieor index int ior ishift ishiftc
-          kind lbound len len_trim lge lgt lle llt log log10 logical matmul max
-          maxexponent maxloc maxval merge min minexponent minloc minval mod
-          modulo mvbits nearest nint not null pack precision present product
-          radix random_number random_seed range real repeat reshape rrspacing
-          scale scan selected_int_kind selected_real_kind set_exponent shape
-          sign sin sinh size spacing spread sqrt sum system_clock tan tanh tiny
-          transfer transpose trim ubound unpack verify
+          abs achar acos acosh adjustl adjustr aimag aint all allocated anint
+          any asin asinh associated atan atan2 atanh bessel_j0 bessel_j1
+          bessel_jn bessel_y0 bessel_y1 bessel_yn bge bgt bit_size ble blt btest
+          c_associated c_f_pointer c_f_procpointer c_funloc c_loc c_sizeof
+          ceiling char cmplx command_argument_count compiler_options
+          compiler_version conjg cos cosh count cpu_time cshift date_and_time
+          dble digits dim dot_product dprod dshiftl dshiftr eoshift epsilon erf
+          erfc_scaled erfc execute_command_line exp exponent extends_type_of
+          findloc floor fraction gamma get_command_argument get_command
+          get_environment_variable huge hypot iachar iall iand iany ibclr ibits
+          ibset ichar ieee_class ieee_copy_sign ieee_get_flag
+          ieee_get_halting_mode ieee_get_rounding_mode ieee_get_status
+          ieee_get_underflow_mode ieee_is_finite ieee_is_nan ieee_is_normal
+          ieee_logb ieee_next_after ieee_rem ieee_rint ieee_scalb
+          ieee_selected_real_kind ieee_set_flag ieee_set_halting_mode
+          ieee_set_rounding_mode ieee_set_status ieee_set_underflow_mode
+          ieee_support_datatype ieee_support_denormal ieee_support_divide
+          ieee_support_flag ieee_support_halting ieee_support_inf
+          ieee_support_io ieee_support_nan ieee_support_rounding
+          ieee_support_sqrt ieee_support_standard ieee_support_underflow_control
+          ieee_unordered ieee_value ieor image_index index int ior iparity
+          is_contiguous is_iostat_end is_iostat_eor ishft ishftc kind lbound
+          lcobound leadz len_trim len lge lgt lle llt log_gamma log log10
+          logical maskl maskr matmul max maxexponent maxloc maxval merge_bits
+          merge min minexponent minloc minval mod modulo move_alloc mvbits
+          nearest new_line nint norm2 not null num_images pack parity popcnt
+          poppar present product radix random_number random_seed range real
+          repeat reshape rrspacing same_type_as scale scan selected_char_kind
+          selected_int_kind selected_real_kind set_exponent shape shifta shiftl
+          shiftr sign sin sinh size spacing spread sqrt storage_size sum
+          system_clock tan tanh this_image tiny trailz transfer transpose trim
+          ubound ucobound unpack verify
         )
       end
 
@@ -63,7 +87,7 @@ module Rouge
         rule /!.*$/, Comment::Single
         rule /^#.*$/, Comment::Preproc
 
-        rule /::|[()\/;,:&]/, Punctuation
+        rule /::|[()\/;,:&\[\]]/, Punctuation
 
         # TODO: This does not take into account line continuation.
         rule /^(\s*)([0-9]+)\b/m do |m|
@@ -99,6 +123,10 @@ module Rouge
 
         rule %r{\*\*|//|==|/=|<=|>=|=>|[-+*/<>=%]}, Operator
         rule /\.(?:EQ|NE|LT|LE|GT|GE|NOT|AND|OR|EQV|NEQV|[A-Z]+)\./i, Operator::Word
+
+        # To make sure "double precision" written as two words is highlighted
+        # properly. "doubleprecision" is covered by a different rule.
+        rule /double\s+precision\b/i, Keyword::Type
 
         rule /#{name}/m do |m|
           match = m[0].downcase

--- a/spec/lexers/fortran_spec.rb
+++ b/spec/lexers/fortran_spec.rb
@@ -3,6 +3,15 @@
 describe Rouge::Lexers::Fortran do
   let(:subject) { Rouge::Lexers::Fortran.new }
 
+  include Support::Lexing
+
+  it 'highlights "double precision" and "double" correctly' do
+    tokens = subject.lex('double precision :: double').to_a
+    assert { tokens.size == 5 }
+    assert { tokens.first[0] == Token['Keyword.Type'] }
+    assert { tokens.last[0] == Token['Name'] }
+  end
+
   describe 'guessing' do
     include Support::Guessing
 

--- a/spec/visual/samples/fortran
+++ b/spec/visual/samples/fortran
@@ -152,4 +152,20 @@ contains
 
     end subroutine print_bottles
 
+    subroutine share_bottles(n, m)
+      use, intrinsic :: ieee_arithmetic
+      implicit none
+      integer, intent(in) :: n, m
+
+      double precision :: double
+      doubleprecision  :: another_double
+
+      if (m == 0) then
+        double = ieee_value(double, IEEE_QUIET_NAN)
+      else
+        double = real(n, kind(double)) / real(m, kind(another_double))
+        print '(A,F0.2,A)', 'Everyone gets ', double, ' bottles!'
+      endif
+    end subroutine share_bottles
+
 end program bottles


### PR DESCRIPTION
Add new keywords and intrinsics from Fortran 2003 and Fortran 2008 standards. Also make sure to highlight "double precision" properly, while not highlighting "double" or "precision" individually (there might be a more elegant way to implement it, though).

Closes #656