### PR TITLE
Add OpenMP lexer for Fortran and C

### DIFF
--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -69,6 +69,15 @@ module Rouge
       state :expr_bol do
         mixin :inline_whitespace
 
+        # OpenMP
+        rule /(^\s*)(#pragma\s+omp)([ \t]*)([^\\\r\n]+)(\\?)$/i do |m|
+          token Text::Whitespace, m[1]
+          token Keyword::Reserved, m[2]
+          token Text::Whitespace, m[3]
+          delegate OpenMP, m[4]
+          token Punctuation, m[5]
+        end
+
         rule /#if\s0/, Comment, :if_0
         rule /#/, Comment::Preproc, :macro
 
@@ -123,6 +132,8 @@ module Rouge
           elsif self.class.reserved.include? name
             token Keyword::Reserved
           elsif self.class.builtins.include? name
+            token Name::Builtin
+          elsif OpenMP::runtimeroutines.include? name
             token Name::Builtin
           else
             token Name

--- a/lib/rouge/lexers/fortran.rb
+++ b/lib/rouge/lexers/fortran.rb
@@ -83,6 +83,16 @@ module Rouge
       end
 
       state :root do
+        # OpenMP
+        rule /(^\s*)(!\$omp)([ \t]*)(&?)([^&\r\n]+)(&?)$/i do |m|
+          token Text::Whitespace, m[1]
+          token Keyword::Reserved, m[2]
+          token Text::Whitespace, m[3]
+          token Punctuation, m[4]
+          delegate OpenMP, m[5]
+          token Punctuation, m[6]
+        end
+
         rule /[\s\n]+/, Text::Whitespace
         rule /!.*$/, Comment::Single
         rule /^#.*$/, Comment::Preproc
@@ -135,6 +145,8 @@ module Rouge
           elsif self.class.types.include? match
             token Keyword::Type
           elsif self.class.intrinsics.include? match
+            token Name::Builtin
+          elsif OpenMP::runtimeroutines.include? match
             token Name::Builtin
           else
             token Name

--- a/lib/rouge/lexers/openmp.rb
+++ b/lib/rouge/lexers/openmp.rb
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class OpenMP < RegexLexer
+      title "OpenMP"
+      desc "OpenMP 4.5 (to be used with Fortran or C lexer)"
+
+      name = /[A-Z][_A-Z]*/i
+
+      def self.directives
+        @directives ||= Set.new %w(
+          end parallel do sections single workshare simd declare task taskloop
+          taskyield target data enter exit update teams distribute master
+          critical barrier taskwait taskgroup atomic flush ordered cancel
+          cancellation point threadprivate reduction
+        )
+      end
+
+      def self.clauses
+        @clauses ||= Set.new %w(
+          if depend default shared private firstprivate lastprivate linear
+          reduction safelen collapse simdlen aligned uniform inbranch
+          notinbranch copyin copyprivate map defaultmap final mergeable priority
+          grainsize num_tasks
+        )
+      end
+
+      def self.runtimeroutines
+        @runtimeroutines ||= Set.new %w(
+          omp_get_num_threads omp_set_num_threads omp_get_max_threads
+          omp_get_thread_num omp_get_num_procs omp_in_parallel omp_set_dynamic
+          omp_get_dynamic omp_get_cancellation omp_set_nested omp_get_nested
+          omp_set_schedule omp_get_schedule omp_get_thread_limit
+          omp_set_max_active_levels omp_get_level omp_get_ancestor_thread_num
+          omp_get_team_size omp_get_active_level omp_in_final omp_get_proc_bind
+          omp_get_num_places omp_get_place_num_procs omp_get_place_proc_ids
+          omp_get_plane_num omp_get_partition_num_places
+          omp_get_partition_place_nums omp_set_default_device
+          omp_get_default_device omp_get_num_devices omp_get_num_teams
+          omp_get_team_num omp_is_initial_device omp_get_initial_device
+          omp_get_max_task_priority omp_init_lock omp_init_nest_lock
+          omp_init_lock_with_hint omp_init_nest_lock_with_hint omp_destroy_lock
+          omp_destroy_nest_lock omp_set_lock omp_set_nest_lock omp_unset_lock
+          omp_unset_nest_lock omp_test_lock omp_test_nest_lock omp_get_wtime
+          omp_get_wtick
+        )
+      end
+
+      state :root do
+        rule /[+-]?\d+/i, Num
+        rule /[,\(\):><\[\]-]/, Punctuation
+        rule /\s/, Text::Whitespace
+
+        rule /#{name}/m do |m|
+          match = m[0].downcase
+
+          if self.class.directives.include? match
+            token Name::Decorator
+          elsif self.class.clauses.include? match
+            token Name::Attribute
+          else
+            token Name
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/visual/samples/c
+++ b/spec/visual/samples/c
@@ -2649,3 +2649,40 @@ fast_yield:
 	return retval;
 }
 
+int main_omp()
+{
+  int i, j;
+  int *ptr_i, *ptr_j;
+
+  i = 1;
+  j = 2;
+
+  ptr_i = &i;
+  ptr_j = &j;
+
+  #pragma omp parallel private(i) firstprivate(j)
+  {
+    i = 3;
+    j = j + 2;
+    assert (*ptr_i == 1 && *ptr_j == 2);
+  }
+
+  assert(i == 1 && j == 2);
+
+  return 0;
+}
+
+void init_matrix(Matrix *mat, int n)
+{
+  mat->A = (double *)malloc(n*sizeof(double));
+  mat->N = n;
+  #pragma omp target enter data map(alloc:mat->A[:n])
+}
+
+void free_matrix(Matrix *mat)
+{
+  #pragma omp target exit data map(delete:mat->A[:mat->N])
+  mat->N = 0;
+  free(mat->A);
+  mat->A = NULL;
+}

--- a/spec/visual/samples/fortran
+++ b/spec/visual/samples/fortran
@@ -169,3 +169,101 @@ contains
     end subroutine share_bottles
 
 end program bottles
+
+module openmp_various_examples
+contains
+
+SUBROUTINE REDUCTION2(A, B, C, D, X, Y, N)
+    REAL :: X(*), A, D
+    INTEGER :: Y(*), N, B, C
+    REAL :: A_P, D_P
+    INTEGER :: I, B_P, C_P
+
+    A = 0
+    B = 0
+    C = Y(1)
+    D = X(1)
+
+    !$OMP PARALLEL SHARED (X, Y, &
+    !$OMP                  A, B, C, D, N) &
+    !$OMP          PRIVATE(A_P, B_P, &
+    !$OMP                  C_P, D_P)
+    PRINT *, 'Parallel Section 1'
+    !$OMP END PARALLEL
+
+    !$OMP PARALLEL SHARED(X, Y, A, B, C, D, N) &
+    !$OMP&         PRIVATE(A_P, B_P, C_P, D_P)
+    PRINT *, 'Parallel Section 2'
+    A_P = 0.0
+    B_P = 0
+    C_P = HUGE(C_P)
+    D_P = -HUGE(D_P)
+
+    !$OMP DO PRIVATE(I)
+    DO I=1,N
+        A_P = A_P + X(I)
+        B_P = IEOR(B_P, Y(I))
+        C_P = MIN(C_P, Y(I))
+        IF (D_P < X(I)) D_P = X(I)
+    END DO
+
+    !$OMP CRITICAL
+    A = A + A_P
+    B = IEOR(B, B_P)
+    C = MIN(C, C_P)
+    D = MAX(D, D_P)
+    !$OMP END CRITICAL
+    !$OMP END PARALLEL
+END SUBROUTINE REDUCTION2
+
+function add1(a,b,fact) result(c)
+!$omp declare simd(add1) uniform(fact)
+    implicit none
+    double precision :: a,b,fact, c
+    c = a + b + fact
+end function
+
+function add2(a,b,i, fact) result(c)
+!$omp declare simd(add2) uniform(a,b,fact) linear(i:1)
+    implicit none
+    integer          :: i
+    double precision :: a(*),b(*),fact, c
+    c = a(i) + b(i) + fact
+end function
+
+subroutine work(a, b, n )
+    implicit none
+    double precision           :: a(n),b(n), tmp
+    integer                    :: n, i
+    double precision, external :: add1, add2
+
+    !$omp simd private(tmp)
+    do i = 1,n
+        tmp  = add1(a(i), b(i), 1.0d0)
+        a(i) = add2(a,    b, i, 1.0d0) + tmp
+        a(i) = a(i) + b(i) + 1.0d0
+    end do
+end subroutine
+
+end module openmp_various_examples
+
+module openmp_example_target_unstructured_data
+  real(8), allocatable :: A(:)
+
+  contains
+    subroutine initialize(N)
+      integer :: N
+
+      print *, 'Maximum number of threads:', omp_get_num_threads()
+      allocate(A(N))
+      !$omp target enter data map(alloc:A)
+
+    end subroutine initialize
+
+    subroutine finalize()
+
+      !$omp target exit data map(delete:A)
+      deallocate(A)
+
+    end subroutine finalize
+end module openmp_example_target_unstructured_data


### PR DESCRIPTION
Includes all OpenMP 4.5 directives, clauses, and runtime library routines and functions.
I added some examples from the "official" OpenMP examples (see https://github.com/OpenMP/Examples).

I'm anything but a Ruby expert, so advice or improvements are highly appreciated. Given that the OpenMP syntax itself is essentially the same for C and Fortran, I added a new lexer for OpenMP and (try to) delegate the appropriate parts from the Fortran and C lexers.

Also I'm not sure the selected tokens (`Keyword::Reserved`, `Name::Decorator`) for the OpenMP statements are appropriate.

Todo (help is appreciated!):
- [ ] Float values inside OpenMP statements don't work yet. That could be something like `!$omp parallel if(float > 0.5_dp)` and should be implemented in a way that works for both languages. It might make sense to treat everything inside parentheses by the "parent" lexer, but I have no idea how to do that elegantly.

Closes #507 