### PR TITLE
Remove tests for highlighting shell prompt

### DIFF
--- a/spec/lexers/shell_spec.rb
+++ b/spec/lexers/shell_spec.rb
@@ -32,49 +32,6 @@ describe Rouge::Lexers::Shell do
     assert { tokens.last[0] == Token['Comment'] }
   end
 
-  it 'parses a basic shell string with a prompt' do
-    # Single '$' prompt
-    tokens = subject.lex('$ foo=bar').to_a
-    assert { tokens.size == 4 }
-    assert { tokens.first[0] == Token['Generic.Prompt'] }
-    # Single '>' prompt
-    tokens = subject.lex('> foo=bar').to_a
-    assert { tokens.size == 4 }
-    assert { tokens.first[0] == Token['Generic.Prompt'] }
-    # Single '%' prompt
-    tokens = subject.lex('% foo=bar').to_a
-    assert { tokens.size == 4 }
-    assert { tokens.first[0] == Token['Generic.Prompt'] }
-    # Complex prompt with trailing '$'
-    tokens = subject.lex('me@host:~$ foo=bar').to_a
-    assert { tokens.size == 4 }
-    assert { tokens.first[0] == Token['Generic.Prompt'] }
-    # Complex prompt with trailing '>'
-    tokens = subject.lex('me@host:~> foo=bar').to_a
-    assert { tokens.size == 4 }
-    assert { tokens.first[0] == Token['Generic.Prompt'] }
-    # Complex prompt with trailing '%'
-    tokens = subject.lex('me@host:~% foo=bar').to_a
-    assert { tokens.size == 4 }
-    assert { tokens.first[0] == Token['Generic.Prompt'] }
-    # Complex prompt with trailing '#'
-    tokens = subject.lex('root@host:/root# foo=bar').to_a
-    assert { tokens.size == 4 }
-    assert { tokens.first[0] == Token['Generic.Prompt'] }
-  end
-
-  it 'does not confuse a prompt with a variable' do
-    tokens = subject.lex('$foo').to_a
-    assert { tokens.size == 1 }
-    assert { tokens.first[0] == Token['Name.Variable'] }
-  end
-
-  it 'does not confuse a prompt with a comment' do
-    tokens = subject.lex('# commentaire').to_a
-    assert { tokens.size == 1 }
-    assert { tokens.first[0] == Token['Comment'] }
-  end
-
   describe 'guessing' do
     include Support::Guessing
 


### PR DESCRIPTION
Hello. Apparently these tests are unnecessary anymore as Rouge doesn't highlight prompts (after ac1d8eb4173248b50ea7c3cf18e203fac4b3ac30). And this fixes CI failing.