### PR TITLE
Add runkit_js lexer

### DIFF
--- a/lib/rouge/demos/runkit_js
+++ b/lib/rouge/demos/runkit_js
@@ -1,0 +1,4 @@
+var getJSON = require("async-get-json");
+// get the current International Space Station position from open-notify.org
+var result = await getJSON("http://api.open-notify.org/iss-now.json");
+result.iss_position;

--- a/lib/rouge/lexers/runkit_js.rb
+++ b/lib/rouge/lexers/runkit_js.rb
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    load_lexer 'javascript.rb'
+
+    class RunKitJS < Javascript
+      tag 'runkit_js'
+      title "RunKit/JavaScript"
+      desc 'a runnable JavaScript parser.'
+      aliases 'runkit_javasript', 'runkit'
+
+      def initialize(opts={})
+        @node_version = opts.delete(:node_version)
+        @read_only = opts.delete(:read_only)
+        @package_resolution_timestamp = opts.delete(:package_resolution_timestamp)
+        @mode = opts.delete(:mode)
+
+        super(opts)
+      end
+
+      def stream_tokens(stream, &b)
+        super(stream, &b)
+        b.call(Token.make_token('', ''), RunKitScript.new(@node_version, @read_only, @package_resolution_timestamp, @mode))
+      end
+
+      class RunKitScript
+        def initialize(node_version, read_only, package_resolution_timestamp, mode)
+          @node_version = node_version
+          @read_only = read_only
+          @package_resolution_timestamp = package_resolution_timestamp
+          @mode = mode
+        end
+
+        def empty?
+          false
+        end
+
+        def scan(b)
+          return 0
+        end
+
+        def gsub(a,b)
+          read_only_prop = @read_only ? "readOnly: \"" + @read_only.to_s + "\"," : ""
+          node_version_prop = @node_version ? "nodeVersion: \"" + @node_version.inspect[1..-2] + "\"," : ""
+          package_resolution_timestamp_prop = @package_resolution_timestamp ? "packageResolutionTimestamp: " + @package_resolution_timestamp + "," : ""
+          mode_prop = @mode ? "mode: \"" + @mode + "\"," : ""
+
+          return "<script src='https://embed.runkit.com'></script><script>
+var script = document.currentScript || (function() {
+  var scripts = document.getElementsByTagName('script');
+  return scripts[scripts.length - 1];
+})();
+
+var parent = script.parentNode;
+parent.removeChild(script);
+var owner = parent;
+while (owner.className !== 'highlight')  owner = owner.parentNode;
+owner.innerHTML = '';
+owner.style.padding = '0 50px';
+owner.style.overflowX = 'hidden';
+owner.style.backgroundColor = 'initial';
+owner.style.border = 'none';
+
+var notebook = RunKit.createNotebook({
+  // the parent element for the new notebook
+  element: owner, #{read_only_prop} #{node_version_prop} #{package_resolution_timestamp_prop} #{mode_prop}
+  // specify the source of the notebook
+  source: RunKit.sourceFromElement(parent)
+})
+</script>"
+        end
+      end
+    end
+  end
+end

--- a/spec/lexers/runkit_js_spec.rb
+++ b/spec/lexers/runkit_js_spec.rb
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::RunKitJS do
+  let(:subject) { Rouge::Lexers::RunKitJS.new }
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it %(doesn't let a bad regex mess up the whole lex) do
+      assert_has_token 'Error',          "var a = /foo;\n1"
+      assert_has_token 'Literal.Number', "var a = /foo;\n1"
+    end
+  end
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename and does not replace existing specialized lexers' do
+      assert_guess Rouge::Lexers::JSX, :filename => 'foo.jsx'
+      assert_guess Rouge::Lexers::JSON, :filename => 'foo.json'
+      assert_guess Rouge::Lexers::Javascript, :filename => 'foo.js'
+    end
+
+  end
+end

--- a/spec/visual/samples/runkit_js
+++ b/spec/visual/samples/runkit_js
@@ -1,0 +1,151 @@
+// vim: ft=javascript
+
+var myFloat = 0.123;
+var myOctal = 0x123;
+var myRegex = /asdf/;
+var myComplicatedRegex = /.[.](?=x\h\[[)])[^.{}abc]{foo}{3,}x{2,3}/
+var myObject = { a: 1, b: 2 }
+
+var ternary = 0 ? 1 : {object_key : 2 ? variable : 3 };
+var ternary2 = a ? { object_key : c } + variable : e;
+var ternary3 = a ? {
+  key1 : var1,
+  key2: var2 ? function() {
+    label1: // break label, not an object key!
+    while(true) {
+      break label1;
+    }
+
+    label2: // also a break label
+    while (true) {
+      break label2;
+    }
+  } + var3: var4, // ternary, not object key
+  key3: 'foo'
+} : 2
+
+var a = {
+  num: 0,
+  func: function() {},
+  str: '',
+  bool: true
+}
+
+var obj =
+  {
+    // comment
+    key: val
+  }
+
+/*!
+ * multiline comment
+ */
+
+var quotedKeys = {
+  "one": 1,
+  "two": 2,
+  "three": 3,
+};
+
+Blag = {};
+jQuery.noConflict();
+
+if (cond)
+{
+  label1:
+  while (cond) break label1;
+}
+
+Blag.ReadMore = (function($) {
+  function getFold(button) {
+    return $(button).siblings('.fold');
+  }
+
+  function expand(e) {
+    e.preventDefault();
+
+    var self = $(this);
+
+    getFold(self).show();
+    self.html('&laquo; less');
+  }
+
+  function contract(e) {
+    e.preventDefault();
+
+    var self = $(this);
+
+    getFold(self).hide();
+    self.html('more &raquo;')
+  }
+
+  function init() {
+    $('a.read-more').toggle(expand, contract);
+  }
+
+  $(document).ready(init);
+})(jQuery);
+
+// evil regexes, from pygments
+
+/regexp/.test(foo) || x = [/regexp/,/regexp/, /regexp/, // comment
+// comment
+/regexp/];
+if (/regexp/.test(string))
+{/regexp/.test(string);};
+x =/regexp/;
+x = /regexp/;
+if (0</regexp/.exec(string) || 1>/regexp/.exec(string))
+x = { u:/regexp/, v: /regexp/ };
+foo();/regexp/.test(string); /regexp/.test(string);
+if (!/regexp/) foobar();
+x = u %/regexp/.exec(string) */regexp/.exec(string) / /regexp/.exec(string);
+x = u?/regexp/.exec(string) : v +/regexp/.exec(string) -/regexp/.exec(string);
+a = u^/regexp/.exec(string) &/regexp/.exec(string) |/regexp/.exec(string) +~/regexp/.exec(string);
+x = /regexp/ /* a comment */ ;
+x = /[reg/exp]/;
+x = 4/2/i;
+x = (a == b) ?/* this is a comment */ c : d;
+/// a comment //
+a = /regex//2/1; //syntactically correct, returns NaN
+
+// bad regexen - should have an error token at the last char and recover
+// on the next line
+var a = /foo
+var b = /[foo
+var c = /valid-regex/
+
+var template = "{{current}} of beer on the wall";
+var stanza = template.replace(/{{current}}/g, "99 bottles");
+
+/* original examples */
+
+// regex
+
+blah(/abc/);
+x = /abc/;
+x = /abc/.match;
+
+// math
+
+blah(1/2); //comment
+x = 1 / 2 / 3;
+x = 1/1/.1;
+
+x=/1/; // regex
+x=1/a/g; // division
+x=a/a/g; // division
+
+// real-world
+
+var x = 1/(1+Math.sqrt(sum)); // convert to number between 1-0
+return Math.round((num / den) * 100)/100;
+
+// generator
+function* range(from, to)
+{
+  to++;
+  while (from > to) {
+    yield from++;
+  }
+}


### PR DESCRIPTION
This branch adds the option to make Node snippets runnable.

This is a Node example being rendered with this lexer, as you can see if you press the "Run" button, you get a cool result. It uses the `runkit_js` tag to make it explicit that you want runnable Node code.

![screen shot 2017-05-10 at 5 52 51 pm copy2](https://cloud.githubusercontent.com/assets/101547/25927569/a6171bc6-35ab-11e7-9215-ee3b1981e670.png)

If JavaScript happens to be turned off, it just falls back to the standard JavaScript Rouge lexer:

![screen shot 2017-05-10 at 5 52 51 pm copy](https://cloud.githubusercontent.com/assets/101547/25927567/a4a92928-35ab-11e7-8a4a-f34d124c513f.png)
