### PR TITLE
add digdag syntax (*.dig)

### DIFF
--- a/lib/rouge/demos/digdag
+++ b/lib/rouge/demos/digdag
@@ -1,0 +1,18 @@
+timezone: UTC
+
++setup:
+  echo>: start ${session_time}
+
++disp_current_date:
+  echo>: ${moment(session_time).utc().format('YYYY-MM-DD HH:mm:ss Z')}
+
++repeat:
+  for_each>:
+    order: [first, second, third]
+    animal: [dog, cat]
+  _do:
+    echo>: ${order} ${animal}
+  _parallel: true
+
++teardown:
+  echo>: finish ${session_time}

--- a/lib/rouge/demos/digdag
+++ b/lib/rouge/demos/digdag
@@ -1,3 +1,4 @@
+# this is digdag task definitions
 timezone: UTC
 
 +setup:

--- a/lib/rouge/lexers/digdag.rb
+++ b/lib/rouge/lexers/digdag.rb
@@ -1,0 +1,18 @@
+module Rouge
+  module Lexers
+    load_lexer 'yaml.rb'
+
+    class Digdag < YAML
+      title 'digdag'
+      desc 'A simple, open source, multi-cloud workflow engine (https://www.digdag.io/)'
+      tag 'digdag'
+      filenames '*.dig'
+
+      mimetypes 'application/x-digdag'
+
+      def self.analyze_text(text)
+        # disable YAML.analyze_text
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/digdag.rb
+++ b/lib/rouge/lexers/digdag.rb
@@ -1,3 +1,4 @@
+require 'set'
 module Rouge
   module Lexers
     load_lexer 'yaml.rb'
@@ -12,6 +13,59 @@ module Rouge
 
       def self.analyze_text(text)
         # disable YAML.analyze_text
+      end
+
+      # http://docs.digdag.io/operators.html
+      # as of digdag v0.9.10
+      KEYWORD_PATTERN = Regexp.union(%w(
+        call
+        require
+        loop
+        for_each
+        if
+        fail
+        echo
+
+        td
+        td_run
+        td_ddl
+        td_load
+        td_for_each
+        td_wait
+        td_wait_table
+        td_partial_delete
+        td_table_export
+
+        pg
+
+        mail
+        http
+        s3_wait
+        redshift
+        redshift_load
+        redshift_unload
+        emr
+
+        gcs_wait
+        bq
+        bq_ddl
+        bq_extract
+        bq_load
+
+        sh
+        py
+        rb
+        embulk
+      ).map { |name| "#{name}>"} + %w(
+        _do
+        _parallel
+      ))
+
+      prepend :block_nodes do
+        rule /(#{KEYWORD_PATTERN})(:)(?=\s|$)/ do |m|
+          groups Keyword::Reserved, Punctuation::Indicator
+          set_indent m[0], :implicit => true
+        end
       end
     end
   end

--- a/lib/rouge/lexers/yaml.rb
+++ b/lib/rouge/lexers/yaml.rb
@@ -8,13 +8,15 @@ module Rouge
       mimetypes 'text/x-yaml'
       tag 'yaml'
       aliases 'yml'
+      filenames '*.yaml', '*.yml'
 
       def self.analyze_text(text)
         # look for the %YAML directive
         return 1 if text =~ /\A\s*%YAML/m
       end
 
-      filenames '*.yaml', '*.yml'
+      SPECIAL_VALUES = Regexp.union(%w(true false null))
+
       # NB: Tabs are forbidden in YAML, which is why you see things
       # like /[ ]+/.
 
@@ -335,6 +337,7 @@ module Rouge
         end
 
         rule /[ ]+/, Str
+        rule SPECIAL_VALUES, Name::Constant
         # regular non-whitespace characters
         rule /[^\s:]+/, Str
       end

--- a/spec/lexers/digdag_spec.rb
+++ b/spec/lexers/digdag_spec.rb
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Digdag do
+  let(:subject) { Rouge::Lexers::Digdag.new }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.dig'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'application/x-digdag'
+    end
+  end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'recognizes one line comment on last line even when not terminated by a new line (#360)' do
+      assert_tokens_equal "+step1:\n  echo> Hello!\n",
+        ["Literal.String", "+step1"],
+        ["Punctuation.Indicator", ":"],
+        ["Text", "\n  "],
+        ["Literal.String", "echo> Hello!"],
+        ["Text", "\n"]
+    end
+  end
+end

--- a/spec/visual/samples/digdag
+++ b/spec/visual/samples/digdag
@@ -1,0 +1,64 @@
+timezone: UTC
+
++emr_cluster:
+  emr>:
+  cluster:
+    name: my-emr-cluster
+    ec2:
+      key: my-ec2-key
+      master_type: m3.2xlarge
+      instances:
+        type: m3.xlarge
+        count: 3
+    applications:
+      - spark
+      - hive
+      - hue
+    bootstrap:
+      - ...
+      - ...
+    tags:
+      foo: bar
+  steps:
+    - type: spark
+      application: jars/foobar.jar
+      args: [foo, the, bar]
+      jars: lib/libfoo.jar
+    - type: spark
+      application: scripts/spark-test.py
+      args: [foo, the, bar]
+    - type: spark-sql
+      query: queries/spark-query.sql
+      result: s3://my-bucket/results/${session_uuid}/
+    - type: hive
+      script: hive/test.q
+      vars:
+        INPUT: s3://my-bucket/hive-input/
+        OUTPUT: s3://my-bucket/hive-output/
+      hiveconf:
+        hive.support.sql11.reserved.keywords: false
+    - type: command
+      command: [echo, hello, world]
+    - type: command
+      command: [echo, hello, world]
+
++emr_steps:
+  emr>:
+  cluster: ${emr.last_cluster_id}
+  steps:
+    - type: spark
+      application: jars/foobar.jar
+      args: [foo, the, bar]
+    - type: spark
+      application: scripts/spark-test.py
+      args: [foo, the, bar]
+    - type: spark-sql
+      query: queries/spark-query.sql
+      result: s3://my-bucket/results/${session_uuid}/
+    - type: command
+      command: echo
+      args: [hello, world]
+    - type: script
+      command: scripts/hello.sh
+      args: [foo, bar]
+


### PR DESCRIPTION
Added digdag support. This is almost the same as YAML, but unlike YAML, the order of keys matters, so I have introduced a new lexer.

* https://www.digdag.io/ - a simple workflow engine developed by @treasure-data
* example files: https://github.com/treasure-data/digdag/tree/master/examples
