### PR TITLE
more strict negative lookahead shell builtins

### DIFF
--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -39,7 +39,7 @@ module Rouge
         rule /\b(#{KEYWORDS})\s*\b/, Keyword
         rule /\bcase\b/, Keyword, :case
 
-        rule /\b(#{BUILTINS})\s*\b(?!\.)/, Name::Builtin
+        rule /\b(#{BUILTINS})\s*\b(?!(\.|-))/, Name::Builtin
         rule /[.](?=\s)/, Name::Builtin
 
         rule /(\b\w+)(=)/ do |m|


### PR DESCRIPTION
changed negative lookahead so that things like `cd cd-hello` don't match the `cd` from the folder name containing a builtin