### PR TITLE
Display help when using rougify with no args

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -66,7 +66,7 @@ module Rouge
       return klass.parse(argv) if klass
 
       case mode
-      when '-h', '--help', 'help', '-help'
+      when '-h', '--help', 'help', '-help', nil
         Help.parse(argv)
       else
         argv.unshift(mode) if mode

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -21,6 +21,11 @@ describe Rouge::CLI do
       let(:argv) { %w(help) }
       it('parses') { assert { Rouge::CLI::Help === subject } }
     end
+
+    describe 'nil' do
+      let(:argv) { %w() }
+      it('parses') { assert { Rouge::CLI::Help === subject } }
+    end
   end
 
   describe Rouge::CLI::Highlight do


### PR DESCRIPTION
Rougify strangely hangs when using `rougify` without any arguments.

This issue might also be related: #688 