### PR TITLE
bump to v2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This log summarizes the changes in each released version of rouge. The versionin
 we use is semver, although we will often release new lexers in minor versions, as a
 practical matter.
 
+## version 2.1.0: 2017-06-07
+
+  * Ruby 2.4 support, now tested via Travis-CI
+  * breaking changes in the HTML Pygment formatter, see ae350ca9386d940
+  * 2 new cli options: --theme and --require
+  * 2 new themes: igor\_pro and pastie
+  * 15 new lexers: awk, digdag, dot, graphql, hylang, igorpro, irb, lasso,
+    mosel, plist, pony, q, sieve, tsx, wollock
+  * lots of bug fixes and improvements
+
 ## version 2.0.7: 2016-11-18
 
   * haml: fix balanced braces in attribute curlies

--- a/lib/rouge/version.rb
+++ b/lib/rouge/version.rb
@@ -2,6 +2,6 @@
 
 module Rouge
   def self.version
-    "2.0.7"
+    "2.1.0"
   end
 end


### PR DESCRIPTION
There have been a lot of changes - including numerous new lexers - since the last release. Also, 2.0.7 was released months ago.

ae350ca9386d940 was a compatibility break, so semver strictly speaking it should bump to 3.0. I took the liberty to use the "relaxed" way documented in the CHANGELOG.md but I totally understand if that is to be fixed.

I tried my best to summarize the changes based on the git diff and commits logs.