### PR TITLE
Fix incorrect breakout regex in SML lexer

### DIFF
--- a/lib/rouge/lexers/sml.rb
+++ b/lib/rouge/lexers/sml.rb
@@ -191,7 +191,7 @@ module Rouge
       end
 
       state :breakout do
-        rule /(?=\w+\b(#{SML.keywords.to_a.join('|')})\b(?!'))/ do
+        rule /(?=\b(#{SML.keywords.to_a.join('|')})\b(?!'))/ do
           pop!
         end
       end


### PR DESCRIPTION
The 'breakout' state rule in the SML lexer was looking for any number
of word characters before keywords. This was causing the lexer
not to pop out of the 'tname' state.