### PR TITLE
don't install gems which might be hard to install on CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,14 @@ gem 'rake'
 # don't try to install redcarpet under jruby
 gem 'redcarpet', :platforms => :ruby
 
-gem 'pry'
+group :development do
+  gem 'pry'
 
-# docs
-gem 'yard'
-gem 'github-markup'
+  # docs
+  gem 'yard'
+  gem 'github-markup'
 
-# for visual tests
-gem 'sinatra'
-gem 'shotgun'
+  # for visual tests
+  gem 'sinatra'
+  gem 'shotgun'
+end


### PR DESCRIPTION
As https://travis-ci.org/jneen/rouge/jobs/240818767 shows, some gems are no longer installable on older rubies. 

Fortunately, these gems seem to be used only for development, so we can just skip installing them on CI.