### PR TITLE
Efforts to reduce warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,46 @@
 AllCops:
   TargetRubyVersion: 2.0
-  DisabledByDefault: true
   DisplayCopNames: true
   Exclude:
     - tasks/**/*.*
+
+Style:
+  Enabled: false
+
+Layout:
+  Enabled: false
+
+Metrics:
+  Enabled: false
+
+Bundler:
+  Enabled: false
+
+Performance/RedundantBlockCall:
+  Enabled: false
+
+Lint/UselessAssignment:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Lint/EndAlignment:
+  Enabled: false
+
+Lint/EmptyWhen:
+  Enabled: false
+
+Lint/UnneededSplatExpansion:
+  Enabled: false
+
+# TODO: enable it in a future because `ruby -w` warns it
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
+# TODO: enable it in a future because `ruby -w` warns it
+Lint/AmbiguousOperator:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,9 @@ Lint/EmptyWhen:
 Lint/UnneededSplatExpansion:
   Enabled: false
 
+Lint/IneffectiveAccessModifier:
+  Enabled: false
+
 # TODO: enable it in a future because `ruby -w` warns it
 Lint/AmbiguousRegexpLiteral:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.0
+  DisabledByDefault: true
+  DisplayCopNames: true
+  Exclude:
+    - tasks/**/*.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ bundler_args: --without development
 before_install: gem update bundler
 script:
   - bundle exec rake
-  - bundle exec rubocop
+  - if `ruby -e 'exit RUBY_VERSION >= "2.0.0"` ; then bundle exec rubocop ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ bundler_args: --without development
 before_install: gem update bundler
 script:
   - bundle exec rake
-  - if `ruby -e 'exit RUBY_VERSION >= "2.0.0"` ; then bundle exec rubocop ; fi
+  - if ruby -e 'exit RUBY_VERSION >= "2.0.0"' ; then bundle exec rubocop ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ rvm:
   - 2.4.0
 bundler_args: --without development
 before_install: gem update bundler
+script:
+  - bundle exec rake
+  - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'minitest', '~> 4.0'
 gem 'wrong'
 
-gem 'rubocop'
+gem 'rubocop', '~> 0.49.1' if RUBY_VERSION >= '2.0.0'
 
 gem 'rake'
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gemspec
 gem 'minitest', '~> 4.0'
 gem 'wrong'
 
+gem 'rubocop'
+
 gem 'rake'
 
 # don't try to install redcarpet under jruby

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'pathname'
 task :spec do
   spec_files = FileList.new(ENV['files'] || './spec/**/*_spec.rb')
   switch_spec_files = spec_files.map { |x| "-r#{x}" }.join(' ')
-  sh "ruby -w -I./lib -r ./spec/spec_helper #{switch_spec_files} -e Minitest::Unit.autorun"
+  sh "ruby -I./lib -r ./spec/spec_helper #{switch_spec_files} -e Minitest::Unit.autorun"
 end
 
 task :doc do

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'pathname'
 task :spec do
   spec_files = FileList.new(ENV['files'] || './spec/**/*_spec.rb')
   switch_spec_files = spec_files.map { |x| "-r#{x}" }.join(' ')
-  sh "ruby -I./lib -r ./spec/spec_helper #{switch_spec_files} -e Minitest::Unit.autorun"
+  sh "ruby -w -I./lib -r ./spec/spec_helper #{switch_spec_files} -e Minitest::Unit.autorun"
 end
 
 task :doc do

--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -282,7 +282,7 @@ module Rouge
         formatter.format(lexer.lex(input), &method(:print))
       end
 
-    private
+    private_class_method
       def self.parse_cgi(str)
         pairs = CGI.parse(str).map { |k, v| [k.to_sym, v.first] }
         Hash[pairs]
@@ -374,7 +374,7 @@ module Rouge
       end
     end
 
-  private
+  private_class_method
     def self.normalize_syntax(argv)
       out = []
       argv.each do |arg|

--- a/lib/rouge/formatters/html.rb
+++ b/lib/rouge/formatters/html.rb
@@ -26,7 +26,7 @@ module Rouge
         end
       end
 
-    private
+
       TABLE_FOR_ESCAPE_HTML = {
         '&' => '&amp;',
         '<' => '&lt;',

--- a/lib/rouge/lexers/elixir.rb
+++ b/lib/rouge/lexers/elixir.rb
@@ -20,7 +20,7 @@ module Rouge
         rule /#.*$/, Comment::Single
         rule %r{\b(case|cond|end|bc|lc|if|unless|try|loop|receive|fn|defmodule|
              defp?|defprotocol|defimpl|defrecord|defmacrop?|defdelegate|
-             defexception|exit|raise|throw|unless|after|rescue|catch|else)\b(?![?!])|
+             defexception|exit|raise|throw|after|rescue|catch|else)\b(?![?!])|
              (?<!\.)\b(do|\-\>)\b}x, Keyword
         rule /\b(import|require|use|recur|quote|unquote|super|refer)\b(?![?!])/, Keyword::Namespace
         rule /(?<!\.)\b(and|not|or|when|xor|in)\b/, Operator::Word

--- a/lib/rouge/lexers/http.rb
+++ b/lib/rouge/lexers/http.rb
@@ -56,7 +56,7 @@ module Rouge
         rule /([^\s:]+)( *)(:)( *)([^\r\n]+)(\r?\n|$)/ do |m|
           key = m[1]
           value = m[5]
-          if key.strip.downcase == 'content-type'
+          if key.strip.casecmp('content-type').zero?
             @content_type = value.split(';')[0].downcase
           end
 

--- a/lib/rouge/lexers/igorpro.rb
+++ b/lib/rouge/lexers/igorpro.rb
@@ -263,7 +263,7 @@ module Rouge
         rule %r(//), Comment, :comments
 
         rule /\b#{object}/ do |m|
-          if m[0].downcase.match /function/
+          if m[0].downcase =~ /function/
             token Keyword::Declaration
             push :parse_function
           elsif self.class.igorDeclarations.include? m[0].downcase
@@ -281,7 +281,7 @@ module Rouge
           elsif self.class.hdf5Operation.include? m[0].downcase
             token Keyword::Reserved
             push :operationFlags
-          elsif m[0].downcase.match /(v|s|w)_[a-z]+[a-z0-9]*/
+          elsif m[0].downcase =~ /(v|s|w)_[a-z]+[a-z0-9]*/
             token Name::Builtin
           else
             token Name

--- a/lib/rouge/lexers/liquid.rb
+++ b/lib/rouge/lexers/liquid.rb
@@ -105,7 +105,7 @@ module Rouge
       state :filters do
         mixin :whitespace
 
-        rule (/\}\}/) { token Punctuation; reset_stack }
+        rule(/\}\}/) { token Punctuation; reset_stack }
 
         rule /([^\s\|:]+)(:?)(\s*)/ do
           groups Name::Function, Punctuation, Text::Whitespace
@@ -156,11 +156,11 @@ module Rouge
       end
 
       state :end_of_tag do
-        rule (/\}\}/) { token Punctuation; reset_stack }
+        rule(/\}\}/) { token Punctuation; reset_stack }
       end
 
       state :end_of_block do
-        rule (/%\}/) { token Punctuation; reset_stack }
+        rule(/%\}/) { token Punctuation; reset_stack }
       end
 
       # states for unknown markup

--- a/lib/rouge/lexers/matlab.rb
+++ b/lib/rouge/lexers/matlab.rb
@@ -11,7 +11,7 @@ module Rouge
       mimetypes 'text/x-matlab', 'application/x-matlab'
 
       def self.analyze_text(text)
-        return 0.4 if text.match(/^\s*% /) # % comments are a dead giveaway
+        return 0.4 if text =~ /^\s*% / # % comments are a dead giveaway
       end
 
       def self.keywords

--- a/lib/rouge/lexers/mosel.rb
+++ b/lib/rouge/lexers/mosel.rb
@@ -73,7 +73,7 @@ module Rouge
         getbstat getdualray getiis getiissense getiistype getinfcause getinfeas getlb getloadedlinctrs getloadedmpvars getname getprimalray getprobstat getrange getsensrng getsize getsol getub getvars
         implies indicator isiisvalid isintegral loadbasis
         loadmipsol loadprob
-        maximize, minimize
+        maximize minimize
         postsolve
         readbasis readdirs readsol refinemipsol rejectintsol repairinfeas resetbasis resetiis resetsol
         savebasis savemipsol savesol savestate selectsol setbstat setcallback setcbcutoff setgndata setlb setmipdir setmodcut setsol setub setucbdata stopoptimize
@@ -100,15 +100,15 @@ module Rouge
         getasnumber getchar getcwd getdate getday getdaynum getdays getdirsep 
         getendparse setendparse
         getenv getfsize getfstat getftime gethour getminute getmonth getmsec getpathsep
-        getqtype, setqtype
+        getqtype setqtype
         getsecond
-        getsepchar, setsepchar
+        getsepchar setsepchar
         getsize
-        getstart, setstart
-        getsucc, setsucc
+        getstart setstart
+        getsucc setsucc
         getsysinfo getsysstat gettime
         gettmpdir 
-        gettrim, settrim
+        gettrim settrim
         getweekday getyear
         inserttext isvalid
         makedir makepath newtar

--- a/lib/rouge/lexers/nasm.rb
+++ b/lib/rouge/lexers/nasm.rb
@@ -139,7 +139,7 @@ module Rouge
 
       state :root do
         mixin :expr_whitespace
-        rule (//) { push :statement }
+        rule(//) { push :statement }
         rule /^%[a-zA-Z0-9]+/, Comment::Preproc, :statement
 
         rule(

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -166,7 +166,7 @@ module Rouge
           push :comma_list
         end
 
-        rule /[\s\n]/,    Text, :pop!
+        rule /[\s]/,    Text, :pop!
       end
 
       state :procedure_call do
@@ -175,7 +175,7 @@ module Rouge
         rule /(:|\s*\()/, Punctuation, :pop!
 
         rule /'/,            Name::Function
-        rule /[^:\('\n\s]+/, Name::Function
+        rule /[^:\('\s]+/, Name::Function
 
         rule /(?=\s+)/ do
           token Text
@@ -187,7 +187,7 @@ module Rouge
       state :procedure_definition do
         rule /(:|\s*\()/, Punctuation, :pop!
 
-        rule /[^:\(\n\s]+/, Name::Function
+        rule /[^:\(\s]+/, Name::Function
 
         rule /(\s+)/, Text, :pop!
       end

--- a/lib/rouge/lexers/protobuf.rb
+++ b/lib/rouge/lexers/protobuf.rb
@@ -53,17 +53,17 @@ module Rouge
 
       state :package do
         rule /[a-zA-Z_]\w*/, Name::Namespace, :pop!
-        rule (//) { pop! }
+        rule(//) { pop! }
       end
 
       state :message do
         rule /[a-zA-Z_]\w*/, Name::Class, :pop!
-        rule (//) { pop! }
+        rule(//) { pop! }
       end
 
       state :type do
         rule /[a-zA-Z_]\w*/, Name, :pop!
-        rule (//) { pop! }
+        rule(//) { pop! }
       end
     end
   end

--- a/lib/rouge/lexers/wollok.rb
+++ b/lib/rouge/lexers/wollok.rb
@@ -71,7 +71,7 @@ module Rouge
       state :objects do
         rule variable_naming do |m|
           variable = m[0]
-          if entities.include?(variable) || ('A'..'Z').include?(variable[0])
+          if entities.include?(variable) || ('A'..'Z').cover?(variable[0])
             token Name::Class
           else
             token Keyword::Variable

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -102,7 +102,7 @@ module Rouge
           proc do |stream|
             puts "    yielding #{tok.qualname}, #{stream[0].inspect}" if @debug
             @output_stream.call(tok, stream[0])
-            puts "    popping stack: #{1}" if @debug
+            puts "    popping stack: 1" if @debug
             @stack.pop or raise 'empty stack!'
           end
         when :push

--- a/lib/rouge/regex_lexer.rb
+++ b/lib/rouge/regex_lexer.rb
@@ -46,6 +46,7 @@ module Rouge
         @name = name
         @defn = defn
         @rules = []
+        @loaded = false
       end
 
       def to_state(lexer_class)
@@ -300,7 +301,7 @@ module Rouge
           # the most common, for now...
           next if rule.beginning_of_line && !stream.beginning_of_line?
 
-          if size = stream.skip(rule.re)
+          if (size = stream.skip(rule.re))
             puts "    got #{stream[0].inspect}" if @debug
 
             instance_exec(stream, &rule.callback)

--- a/lib/rouge/util.rb
+++ b/lib/rouge/util.rb
@@ -7,10 +7,10 @@ module Rouge
     end
 
     def [](k)
-      _sup = super
-      return _sup if own_keys.include?(k)
+      value = super
+      return value if own_keys.include?(k)
 
-      _sup || parent[k]
+      value || parent[k]
     end
 
     def parent


### PR DESCRIPTION
I've found that `RUBYOPT=-w` produces lots of warnings. In fact, I found it in testing a ruby gem that depends on rouge, which output is flushed by lots of warnings from rouge. 

This PR reduces them; some are powered by rubocop. However, some warnings are difficult to solve -- please try `rake RUBYOPT=-w` -- but I'll continue to reduce them in some separate PRs.

@jneen what do you think of this kind of efforts?