### PR TITLE
fix rackup failure

### DIFF
--- a/spec/visual/app.rb
+++ b/spec/visual/app.rb
@@ -2,7 +2,7 @@
 
 require 'rubygems'
 require 'bundler'
-Bundler.require
+Bundler.require(:default, :development)
 
 # stdlib
 require 'pathname'


### PR DESCRIPTION
A degrade by https://github.com/jneen/rouge/pull/693 , which introduces `development` group in Gemfile, causing:

```console
$ bundle exec rackup
bundler: failed to load command: rackup (/Users/gfx/.rbenv/versions/2.3.1/bin/rackup)
NameError: uninitialized constant Sinatra
```