### PR TITLE
Trap PIPE only when platform supports it; fix #688

### DIFF
--- a/bin/rougify
+++ b/bin/rougify
@@ -4,7 +4,7 @@ require 'pathname'
 ROOT_DIR = Pathname.new(__FILE__).dirname.parent
 load ROOT_DIR.join('lib/rouge.rb')
 load ROOT_DIR.join('lib/rouge/cli.rb')
-Signal.trap('SIGPIPE', 'SYSTEM_DEFAULT')
+Signal.trap('PIPE', 'SYSTEM_DEFAULT') if Signal.list.include? 'PIPE'
 
 begin
   Rouge::CLI.parse(ARGV).run


### PR DESCRIPTION
Tested on Linux, macOS, and Windows.