### PR TITLE
tweaks for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Gemfile.lock
 
 # tmp
 /tmp
+
+# IntelliJ IDEA / RubyMine
+.idea/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,8 @@ AllCops:
   TargetRubyVersion: 2.0
   DisplayCopNames: true
   Exclude:
-    - tasks/**/*.*
+    - "tasks/**/*"
+    - "vendor/**/*"
 
 Style:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+dist: trusty
 language: ruby
 rvm:
   - "1.9.3"
@@ -5,7 +7,10 @@ rvm:
   - "2.1"
   - "2.2"
   - "2.3"
-  - 2.4.0
+  - "2.4"
+
+cache:
+  bundler: true
 bundler_args: --without development
 before_install: gem update bundler
 script:


### PR DESCRIPTION
some tweaks for CI:

* specify ruby version as "2.4" instead of "2.4.0" to use the latest 2.4.x release
* use "trusty" dist (i.e. ubuntu 14.x) instead of the default (ubuntu 12.x)
* use bundler cache to speed up CI builds