### PR TITLE
Add the .arb file extension to ruby highlighting

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -9,7 +9,7 @@ module Rouge
       aliases 'rb'
       filenames '*.rb', '*.ruby', '*.rbw', '*.rake', '*.gemspec', '*.podspec',
                 'Rakefile', 'Guardfile', 'Gemfile', 'Capfile', 'Podfile',
-                'Vagrantfile', '*.ru', '*.prawn', 'Berksfile'
+                'Vagrantfile', '*.ru', '*.prawn', 'Berksfile', '*.arb'
 
       mimetypes 'text/x-ruby', 'application/x-ruby'
 


### PR DESCRIPTION
The `.arb` file extension is used for [arbre](https://github.com/activeadmin/arbre), a ruby HTML DSL. It currently does not have syntax highlighting on GitLab. The highlighting should be treated as ruby.