### PR TITLE
Fix licenses in gemspec to Rubygems standard

### DIFF
--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "rouge"
   s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'lib/**/*.yml', 'bin/rougify', 'lib/rouge/demos/*']
   s.executables = %w(rougify)
-  s.license = 'MIT, 2-clause BSD'
+  s.licenses = ['MIT', 'BSD-2-Clause']
 end


### PR DESCRIPTION
According to [Rubygems](http://guides.rubygems.org/specification-reference/#licenses=), you should specify your license using an [SPDX ID](https://spdx.org/licenses/) and arrays of strings where multiple licenses are relevant. This permits tools like [LicenseFinder](https://github.com/pivotal/LicenseFinder) to properly find the relevant data.

The only thing that this PR does is specify the two existing licenses (MIT and 2-clause "Simplified" BSD) in this way.