### PR TITLE
Fixed rules for numeric literals in Q.  Closes #715.

### DIFF
--- a/lib/rouge/lexers/q.rb
+++ b/lib/rouge/lexers/q.rb
@@ -94,8 +94,11 @@ module Rouge
         rule(%r{'|\/:|\\:|':|\\|\/|0:|1:|2:}, Operator)
 
         ## numbers
-        rule(/(?:\d+(?:\.\d*)?|\.\d+)(?:e[+\-]?\d+|\d+\.\d*|\.\d+)?[ef]?/, Num::Float)
-        rule(/[01]+b?/, Num)
+        rule(/(\d+[.]\d*|[.]\d+)(e[+-]?\d+)?[ef]?/, Num::Float)
+        rule(/\d+e[+-]?\d+[ef]?/, Num::Float)
+        rule(/\d+[ef]/, Num::Float)
+        rule(/0x[0-9a-f]+/i, Num::Hex)
+        rule(/[01]+b/, Num::Bin)
         rule(/[0-9]+[hij]?/, Num::Integer)
         ## symbols and paths
         rule(%r{(`:[:a-z0-9._\/]*|`(?:[a-z0-9.][:a-z0-9._]*)?)}i, Str::Symbol)

--- a/spec/visual/samples/q
+++ b/spec/visual/samples/q
@@ -17,8 +17,8 @@ f:{ / but this comment will not continue
    x + y}
 
 / Over and scan
-f/1 2 3
-f\1 2 3
+f/1 2 3h
+f\1 2 3i
 
 do|if|while|select|update|delete|exec|from|by
 
@@ -59,6 +59,10 @@ iasc|idesc|inv|keys|load|log|lsq|ltime|ltrim|maxs|md5|meta|mins|next|parse|plist
 10 10.1 10e10 10e-10 .1 .1e+10
 10e 10.1e 10e10e 10e-10e .1e .1e+10e
 10f 10.1f 10e10f 10e-10f .1f .1e+10f
+
+0x123AF, 0xabcd12
+
+101h, 102i, 103j
 
 `sym`a_b
 `:path`:/a/b/c


### PR DESCRIPTION
 * Do not mistake integers for floats.
 * Recognize byte vectors (e.g. 0x12EF).