### PR TITLE
Enable the null formatter.  Closes #718.

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -273,6 +273,7 @@ module Rouge
         when 'html-pygments' then Formatters::HTMLPygments.new(Formatters::HTML.new, opts[:css_class])
         when 'html-inline' then Formatters::HTMLInline.new(theme)
         when 'html-table' then Formatters::HTMLTable.new(Formatters::HTML.new)
+        when 'null', 'raw', 'tokens' then Formatters::Null.new
         else
           error! "unknown formatter preset #{opts[:formatter]}"
         end


### PR DESCRIPTION
The null formatter formats tokens as a raw representation for
storing token streams or debuging.  To specify the null formatter,
use "-f null", "-f raw" or "-f tokens" command line option.

For example,

$ echo "1+2"| rougify -l ruby -f tokens
Rouge::Token::Tokens::Num::Integer "1"
Rouge::Token::Tokens::Operator "+"
Rouge::Token::Tokens::Num::Integer "2"
Rouge::Token::Tokens::Text "\n"
