### PR TITLE
Fix small bug with JavaScript lexer

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -198,10 +198,22 @@ module Rouge
         rule /0o[0-7][0-7_]*/i, Num::Oct
         rule /0b[01][01_]*/i, Num::Bin
         rule /[0-9]+/, Num::Integer
-    
-        rule /"(\\[\\"]|[^"])*"/, Str::Double
-        rule /'(\\[\\']|[^'])*'/, Str::Single
+
+        rule /"/, Str::Double, :dq
+        rule /'/, Str::Single, :sq
         rule /:/, Punctuation
+      end
+
+      state :dq do
+        rule /[^\\"]+/, Str::Double
+        rule /\\"/, Str::Escape
+        rule /"/, Str::Double, :pop!
+      end
+
+      state :sq do
+        rule /[^\\']+/, Str::Single
+        rule /\\'/, Str::Escape
+        rule /'/, Str::Single, :pop!
       end
 
       # braced parts that aren't object literals

--- a/spec/visual/samples/html
+++ b/spec/visual/samples/html
@@ -6,6 +6,9 @@
         var el = document.getElementById(id);
     }
 </script>
+
+<script> "hello < world" </script>
+<script> 'hello < world' </script>
 <style>
 .syntax { border: 1px solid #d0d0d0; background-color: #f0f0f0;
           margin-left: 10px; margin-right: 10px; }


### PR DESCRIPTION
The JavaScript lexer would misinterpret regex if they were between single and double quotation.