### PR TITLE
Don't default to a hash in Lexer.format

### DIFF
--- a/lib/rouge/formatter.rb
+++ b/lib/rouge/formatter.rb
@@ -21,8 +21,8 @@ module Rouge
     end
 
     # Format a token stream.  Delegates to {#format}.
-    def self.format(tokens, opts={}, &b)
-      new(opts).format(tokens, &b)
+    def self.format(tokens, *a, &b)
+      new(*a).format(tokens, &b)
     end
 
     def initialize(opts={})


### PR DESCRIPTION
Fixes, e.g. `Rouge::Formatters::Terminal256.format(tokens)`