### PR TITLE
use the token's qualname in null formatter

### DIFF
--- a/lib/rouge/formatters/null.rb
+++ b/lib/rouge/formatters/null.rb
@@ -11,7 +11,7 @@ module Rouge
 
       def stream(tokens, &b)
         tokens.each do |tok, val|
-          yield "#{tok} #{val.inspect}\n"
+          yield "#{tok.qualname} #{val.inspect}\n"
         end
       end
     end

--- a/spec/formatters/null_spec.rb
+++ b/spec/formatters/null_spec.rb
@@ -4,9 +4,9 @@ describe Rouge::Formatters::Null do
   let(:subject) { Rouge::Formatters::Null.new }
 
   it 'renders nothing' do
-    result = subject.format([[Token['Text'], 'foo']])
+    result = subject.format([[Token['Name.Constant'], 'foo']])
 
-    assert { result == %|Rouge::Token::Tokens::Text "foo"\n| }
+    assert { result == %|Name.Constant "foo"\n| }
   end
 
   it 'consumes tokens' do


### PR DESCRIPTION
instead of to_s. The output would be, e.g. `Name.Keyword` instead of `Rouge::Tokens::Name::Keyword`.