### PR TITLE
Add support for the Nix expression language

### DIFF
--- a/lib/rouge/demos/nix
+++ b/lib/rouge/demos/nix
@@ -4,6 +4,10 @@
 stdenv.mkDerivation { // 2
   name = "hello-2.1.1"; // 3
   builder = ./builder.sh; // 4
+  meta = rec {
+    name = "rouge";
+    version = "${name}-2.1.1"
+  };
   src = fetchurl { 5
     url = ftp://ftp.nluug.nl/pub/gnu/hello/hello-2.1.1.tar.gz;
     md5 = "70c9ccf9fac07f762c24f2df2290784d";

--- a/lib/rouge/demos/nix
+++ b/lib/rouge/demos/nix
@@ -1,0 +1,12 @@
+# See https://nixos.org/nix/manual/#sec-expression-syntax
+{ stdenv, fetchurl, perl }: // 1
+
+stdenv.mkDerivation { // 2
+  name = "hello-2.1.1"; // 3
+  builder = ./builder.sh; // 4
+  src = fetchurl { 5
+    url = ftp://ftp.nluug.nl/pub/gnu/hello/hello-2.1.1.tar.gz;
+    md5 = "70c9ccf9fac07f762c24f2df2290784d";
+  };
+  inherit perl; // 6
+}

--- a/lib/rouge/demos/nix
+++ b/lib/rouge/demos/nix
@@ -1,16 +1,19 @@
 # See https://nixos.org/nix/manual/#sec-expression-syntax
-{ stdenv, fetchurl, perl }: // 1
+{ stdenv, fetchurl, perl }: # 1
 
-stdenv.mkDerivation { // 2
-  name = "hello-2.1.1"; // 3
-  builder = ./builder.sh; // 4
+stdenv.mkDerivation { # 2
+  name = "hello-2.1.1"; # 3
+  builder = ./builder.sh; # 4
   meta = rec {
     name = "rouge";
-    version = "${name}-2.1.1"
+    version = "${name}-2.1.1";
+    number = 55 + 12;
+    isSmaller = number < 42;
+    bool = true;
   };
-  src = fetchurl { 5
-    url = ftp://ftp.nluug.nl/pub/gnu/hello/hello-2.1.1.tar.gz;
+  src = fetchurl { # 5
+    url = ftp://ftp.nluug.nl/pub/gnu/hello/hello-2.1.1.tar.gz; # path
     md5 = "70c9ccf9fac07f762c24f2df2290784d";
   };
-  inherit perl; // 6
+  inherit perl; # 6
 }

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class Nix < RegexLexer
+      title 'Nix'
+      desc 'The Nix expression language (https://nixos.org/nix/manual/#ch-expression-language)'
+      tag 'nix'
+      aliases 'nixos'
+      filenames '*.nix'
+      state :root do
+        rule /.*/m, Text
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -8,8 +8,42 @@ module Rouge
       tag 'nix'
       aliases 'nixos'
       filenames '*.nix'
+
+      state :number do
+        rule /[0-9]/, Num::Integer
+      end
+
+      state :boolean do
+        rule /(true|false)/, Keyword::Pseudo
+      end
+
+      state :string do
+        rule /"/, Str::Double, :double_quoted_string
+      end
+
+      state :interpolated_string_arg do
+        mixin :expression
+        rule /}/, Str::Interpol, :pop!
+      end
+
+      state :double_quoted_string do
+        #rule "\\.", Str::Escape
+        rule /"/, Str::Double, :pop!
+        rule /\${/, Str::Interpol, :interpolated_string_arg
+        rule /./, Str::Double
+      end
+      
+      state :expression do
+        mixin :number
+        mixin :boolean
+        mixin :string
+      end
+
       state :root do
-        rule /.*/m, Text
+        mixin :expression
+      end
+
+      start do
       end
     end
   end

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -80,6 +80,10 @@ module Rouge
       end
       
       state :expression do
+        mixin :ignore
+        mixin :comment
+        mixin :operator
+        mixin :assignment
         mixin :boolean
         mixin :null
         mixin :number
@@ -93,10 +97,7 @@ module Rouge
 
       state :root do
         mixin :ignore
-        mixin :comment
         mixin :expression
-        mixin :operator
-        mixin :assignment
       end
 
       start do

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -129,7 +129,7 @@ module Rouge
       end
 
       state :keywords_declaration do
-        keywords = %w(let in )
+        keywords = %w(let)
         rule /(?:#{keywords.join('|')})\b/, Keyword::Declaration
       end
 

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -40,6 +40,17 @@ module Rouge
         rule /[a-zA-Z_][a-zA-Z0-9-]*/, Name::Variable
       end
 
+      state :path do
+        word = "[a-zA-Z0-9\._-]+"
+        section = "(\/#{word})"
+        prefix = "[a-z\+]+:\/\/"
+        root = /#{section}+/.source
+        tilde = /~#{section}+/.source
+        basic = /#{word}(\/#{word})+/.source
+        url = /#{prefix}(\/?#{basic})/.source
+        rule /(#{root}|#{tilde}|#{basic}|#{url})/, Str::Other
+      end
+
       state :string do
         rule /"/, Str::Double, :string_double_quoted
         rule /''/, Str::Double, :string_indented
@@ -104,14 +115,15 @@ module Rouge
       state :expression do
         mixin :ignore
         mixin :comment
-        mixin :operator
-        mixin :assignment
-        mixin :delimiter
         mixin :boolean
         mixin :null
         mixin :number
+        mixin :path
         mixin :string
         mixin :keywords
+        mixin :operator
+        mixin :assignment
+        mixin :delimiter
         mixin :binding
         mixin :atom
         mixin :set

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -9,6 +9,11 @@ module Rouge
       aliases 'nixos'
       filenames '*.nix'
 
+      state :whitespaces do
+        rule /^\s*\n\s*$/m, Text
+        rule /\s+/, Text
+      end
+
       state :comment do
         rule /\/\/.*$/, Comment
         rule /\/\*/, Comment, :multiline_comment
@@ -23,8 +28,12 @@ module Rouge
         rule /[0-9]/, Num::Integer
       end
 
+      state :null do
+        rule /(null)/, Keyword::Constant
+      end
+
       state :boolean do
-        rule /(true|false)/, Keyword::Pseudo
+        rule /(true|false)/, Keyword::Constant
       end
 
       state :binding do
@@ -61,17 +70,33 @@ module Rouge
         rule /"/, Str::Double, :pop!
         rule /./, Str::Double
       end
+
+      state :operator do
+        rule /(\.|\?|\+\+|\+|!=|!|\/\/|\=\=|&&|\|\||->|\/|\*|-)/, Operator
+      end
+
+      state :assignment do
+        rule /(=)/, Operator
+      end
       
       state :expression do
-        mixin :number
         mixin :boolean
+        mixin :null
+        mixin :number
         mixin :string
         mixin :binding
       end
 
+      state :ignore do
+        mixin :whitespaces
+      end
+
       state :root do
+        mixin :ignore
         mixin :comment
         mixin :expression
+        mixin :operator
+        mixin :assignment
       end
 
       start do

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -83,7 +83,7 @@ module Rouge
       end
 
       state :operator do
-        rule /(\.|\?|\+\+|\+|!=|!|\/\/|\=\=|&&|\|\||->|\/|\*|-)/, Operator
+        rule /(\.|\?|\+\+|\+|!=|!|\/\/|\=\=|&&|\|\||->|\/|\*|-|<|>|<=|=>)/, Operator
       end
 
       state :assignment do

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -82,6 +82,15 @@ module Rouge
       state :delimiter do
         rule /(;|,|:)/, Punctuation
       end
+
+      state :atom_content do
+        mixin :expression
+        rule /\)/, Punctuation, :pop!
+      end
+
+      state :atom do
+        rule /\(/, Punctuation, :atom_content
+      end
       
       state :expression do
         mixin :ignore
@@ -94,6 +103,7 @@ module Rouge
         mixin :number
         mixin :string
         mixin :binding
+        mixin :atom
       end
 
       state :ignore do

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -9,6 +9,16 @@ module Rouge
       aliases 'nixos'
       filenames '*.nix'
 
+      state :comment do
+        rule /\/\/.*$/, Comment
+        rule /\/\*/, Comment, :multiline_comment
+      end
+
+      state :multiline_comment do
+        rule /\*\//, Comment, :pop!
+        rule /./, Comment
+      end
+
       state :number do
         rule /[0-9]/, Num::Integer
       end
@@ -40,6 +50,7 @@ module Rouge
       end
 
       state :root do
+        mixin :comment
         mixin :expression
       end
 

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -111,9 +111,31 @@ module Rouge
         mixin :null
         mixin :number
         mixin :string
+        mixin :keywords
         mixin :binding
         mixin :atom
         mixin :set
+      end
+
+      state :keywords do
+        mixin :keywords_namespace
+        mixin :keywords_declaration
+        mixin :keywords_conditional
+      end
+
+      state :keywords_namespace do
+        keywords = %w(with in)
+        rule /(?:#{keywords.join('|')})\b/, Keyword::Namespace
+      end
+
+      state :keywords_declaration do
+        keywords = %w(let in )
+        rule /(?:#{keywords.join('|')})\b/, Keyword::Declaration
+      end
+
+      state :keywords_conditional do
+        keywords = %w(if then else)
+        rule /(?:#{keywords.join('|')})\b/, Keyword
       end
 
       state :ignore do

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -103,6 +103,15 @@ module Rouge
         rule /\(/, Punctuation, :atom_content
       end
 
+      state :list do
+        rule /\[/, Punctuation, :list_content
+      end
+
+      state :list_content do
+        rule /\]/, Punctuation, :pop!
+        mixin :expression
+      end
+
       state :set do
         rule /{/, Punctuation, :set_content
       end
@@ -127,6 +136,7 @@ module Rouge
         mixin :binding
         mixin :atom
         mixin :set
+        mixin :list
       end
 
       state :keywords do

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -88,6 +88,11 @@ module Rouge
 
       state :assignment do
         rule /(=)/, Operator
+        rule /(@)/, Operator
+      end
+
+      state :accessor do
+        rule /(\$)/, Punctuation
       end
 
       state :delimiter do
@@ -131,6 +136,7 @@ module Rouge
         mixin :string
         mixin :keywords
         mixin :operator
+        mixin :accessor
         mixin :assignment
         mixin :delimiter
         mixin :binding

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -27,6 +27,10 @@ module Rouge
         rule /(true|false)/, Keyword::Pseudo
       end
 
+      state :binding do
+        rule /[a-zA-Z_][a-zA-Z0-9]*/, Name::Variable
+      end
+
       state :string do
         rule /"/, Str::Double, :double_quoted_string
       end
@@ -47,6 +51,7 @@ module Rouge
         mixin :number
         mixin :boolean
         mixin :string
+        mixin :binding
       end
 
       state :root do

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -133,6 +133,7 @@ module Rouge
         mixin :keywords_namespace
         mixin :keywords_declaration
         mixin :keywords_conditional
+        mixin :keywords_reserved
       end
 
       state :keywords_namespace do
@@ -148,6 +149,11 @@ module Rouge
       state :keywords_conditional do
         keywords = %w(if then else)
         rule /(?:#{keywords.join('|')})\b/, Keyword
+      end
+
+      state :keywords_reserved do
+        keywords = %w(rec assert map)
+        rule /(?:#{keywords.join('|')})\b/, Keyword::Reserved
       end
 
       state :ignore do

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -150,6 +150,7 @@ module Rouge
         mixin :keywords_declaration
         mixin :keywords_conditional
         mixin :keywords_reserved
+        mixin :keywords_builtin
       end
 
       state :keywords_namespace do
@@ -169,6 +170,22 @@ module Rouge
 
       state :keywords_reserved do
         keywords = %w(rec assert map)
+        rule /(?:#{keywords.join('|')})\b/, Keyword::Reserved
+      end
+
+      state :keywords_builtin do
+        keywords = %w(
+          abort
+          baseNameOf
+          builtins
+          derivation
+          fetchTarball
+          import
+          isNull
+          removeAttrs
+          throw
+          toString
+        )
         rule /(?:#{keywords.join('|')})\b/, Keyword::Reserved
       end
 

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -78,12 +78,17 @@ module Rouge
       state :assignment do
         rule /(=)/, Operator
       end
+
+      state :delimiter do
+        rule /(;|,|:)/, Punctuation
+      end
       
       state :expression do
         mixin :ignore
         mixin :comment
         mixin :operator
         mixin :assignment
+        mixin :delimiter
         mixin :boolean
         mixin :null
         mixin :number

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -15,7 +15,7 @@ module Rouge
       end
 
       state :comment do
-        rule /\/\/.*$/, Comment
+        rule /#.*$/, Comment
         rule /\/\*/, Comment, :multiline_comment
       end
 

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -28,7 +28,7 @@ module Rouge
       end
 
       state :binding do
-        rule /[a-zA-Z_][a-zA-Z0-9]*/, Name::Variable
+        rule /[a-zA-Z_][a-zA-Z0-9-]*/, Name::Variable
       end
 
       state :string do

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -32,18 +32,33 @@ module Rouge
       end
 
       state :string do
-        rule /"/, Str::Double, :double_quoted_string
+        rule /"/, Str::Double, :string_double_quoted
+        rule /''/, Str::Double, :string_indented
       end
 
-      state :interpolated_string_arg do
+      state :string_content do
+        rule /\${/, Str::Interpol, :string_interpolated_arg
+        mixin :escaped_sequence
+      end
+
+      state :escaped_sequence do
+        rule /\\./, Str::Escape
+      end
+
+      state :string_interpolated_arg do
         mixin :expression
         rule /}/, Str::Interpol, :pop!
       end
 
-      state :double_quoted_string do
-        #rule "\\.", Str::Escape
+      state :string_indented do
+        mixin :string_content
+        rule /''/, Str::Double, :pop!
+        rule /./, Str::Double
+      end
+
+      state :string_double_quoted do
+        mixin :string_content
         rule /"/, Str::Double, :pop!
-        rule /\${/, Str::Interpol, :interpolated_string_arg
         rule /./, Str::Double
       end
       

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -147,7 +147,7 @@ module Rouge
       end
 
       state :keywords_namespace do
-        keywords = %w(with in)
+        keywords = %w(with in inherit)
         rule /(?:#{keywords.join('|')})\b/, Keyword::Namespace
       end
 

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -91,6 +91,15 @@ module Rouge
       state :atom do
         rule /\(/, Punctuation, :atom_content
       end
+
+      state :set do
+        rule /{/, Punctuation, :set_content
+      end
+
+      state :set_content do
+        rule /}/, Punctuation, :pop!
+        mixin :expression
+      end
       
       state :expression do
         mixin :ignore
@@ -104,6 +113,7 @@ module Rouge
         mixin :string
         mixin :binding
         mixin :atom
+        mixin :set
       end
 
       state :ignore do

--- a/spec/lexers/nix_spec.rb
+++ b/spec/lexers/nix_spec.rb
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Nix do
+  let(:subject) { Rouge::Lexers::Nix.new }
+
+  describe 'lexing' do
+    include Support::Lexing
+  end
+end

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -35,6 +35,39 @@ variable-y = variableX // note that the '-' character may be part of the variabl
 
 __variable__z_ = variable-y
 
+"Escaped chars ${x} \n \r \t \${q}"
+
+// Examples from https://nixos.org/nix/manual/#idm140737318143152
+
+"--with-freetype2-library=${freetype}/lib"
+
+"--with-freetype2-library=" + freetype + "/lib"
+
+configureFlags = "
+  -system-zlib -system-libpng -system-libjpeg
+  ${if openglSupport then "-dlopen-opengl
+    -L${mesa}/lib -I${mesa}/include
+    -L${libXmu}/lib -I${libXmu}/include" else ""}
+  ${if threadSupport then "-thread" else "-no-thread"}
+";
+
+// indented string
+indented = ''
+  This is the first line.
+  This is the second line.
+    This is the third line.
+'';
+
+stdenv.mkDerivation {
+  postInstall =
+    ''
+      mkdir $out/bin $out/etc
+      cp foo $out/bin
+      echo "Hello World" > $out/etc/foo.conf
+      ${if enableBar then "cp bar $out/bin" else ""}
+    '';
+}
+
 { stdenv, fetchurl, perl }: // 1
 
 stdenv.mkDerivation { // 2

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -25,6 +25,12 @@ false
 
 binding
 
+_12 = "twelve"
+
+variableX = _12
+
+variable-y = variableX // note that the '-' character may be part of the variable name
+
 { stdenv, fetchurl, perl }: // 1
 
 stdenv.mkDerivation { // 2

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -1,11 +1,11 @@
-// inline comments
-// another inline comment
+# inline comments
+# another inline comment
 
-// inline comment after empty line
+# inline comment after empty line
 
-  // inline comment after white-space
+  # inline comment after white-space
 
-12 // EOL comment
+12 # EOL comment
 
 /* multi-line
  * comment
@@ -39,13 +39,13 @@ __blah = _12
 
 variableX = _12
 
-variable-y = variableX // note that the '-' character may be part of the variable name
+variable-y = variableX # note that the '-' character may be part of the variable name
 
 __variable__z_ = variable-y
 
 "Escaped chars ${x} \n \r \t \${q}"
 
-// Examples from https://nixos.org/nix/manual/#idm140737318143152
+# Examples from https://nixos.org/nix/manual/#idm140737318143152
 
 "--with-freetype2-library=${freetype}/lib"
 
@@ -59,7 +59,7 @@ configureFlags = "
   ${if threadSupport then "-thread" else "-no-thread"}
 ";
 
-// indented string
+# indented string
 indented = ''
   This is the first line.
   This is the second line.
@@ -108,24 +108,24 @@ in with as; x + y
 
 with (import ./definitions.nix); ...
 
-{ stdenv, fetchurl, perl }: // 1
+{ stdenv, fetchurl, perl }: # 1
 
-stdenv.mkDerivation { // 2
-  name = "hello-2.1.1"; // 1: String
-  // 2: Multiline string
+stdenv.mkDerivation { # 2
+  name = "hello-2.1.1"; # 1: String
+  # 2: Multiline string
   configureFlags  = "
   ";
   meta = {
-    // 3: Indented string
+    # 3: Indented string
     description = ''
     A contrived example of a Nix expression, suitable for testing the lexer for
     Rouge.
     '';
   };
-  builder = ./builder.sh; // 4
+  builder = ./builder.sh; # 4
   src = fetchurl { 5
     url = ftp://ftp.nluug.nl/pub/gnu/hello/hello-2.1.1.tar.gz;
     md5 = "70c9ccf9fac07f762c24f2df2290784d";
   };
-  inherit perl; // 6
+  inherit perl; # 6
 }

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -27,9 +27,13 @@ binding
 
 _12 = "twelve"
 
+__blah = _12
+
 variableX = _12
 
 variable-y = variableX // note that the '-' character may be part of the variable name
+
+__variable__z_ = variable-y
 
 { stdenv, fetchurl, perl }: // 1
 

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -27,6 +27,10 @@ ab = q
 
 12 + 3 / 2 * 1
 
+a < 42 || b <= 10
+
+b > 10 && 42 >= 12
+
 "this is a string"
 
 "interpolated ${x}"

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -31,18 +31,6 @@ ab = q
 
 "interpolated ${x}"
 
-reference
-
-_12 = "twelve"
-
-__blah = _12
-
-variableX = _12
-
-variable-y = variableX # note that the '-' character may be part of the variable name
-
-__variable__z_ = variable-y
-
 "Escaped chars ${x} \n \r \t \${q}"
 
 # Examples from https://nixos.org/nix/manual/#idm140737318143152
@@ -76,6 +64,19 @@ stdenv.mkDerivation {
     '';
 }
 
+reference
+
+_12 = "twelve"
+
+__blah = _12
+
+variableX = _12
+
+variable-y = variableX # note that the '-' character may be part of the variable name
+
+__variable__z_ = variable-y
+
+
 # paths
 
 /bin/sh
@@ -97,7 +98,93 @@ file:///tmp/nixos
 
 / # not a path
 
+# lists
+
+[ 123 ./foo.nix "abc" (f { x = y; }) ]
+
+[ 123 ./foo.nix "abc" f { x = y; } ]
+
+# sets
+
+{ x = 123;
+  text = "Hello";
+  y = f { bla = 456; };
+}
+
+{ a = "Foo"; b = "Bar"; }.a
+
+{ a = "Foo"; b = "Bar"; }.c or "Xyzzy"
+
+{ "foo ${bar}" = 123; "nix-1.0" = 456; }."foo ${bar}"
+
+{ foo = 123; }.${bar} or 456
+
+{ ${if foo then "bar" else null} = true; }
+
+# recursive sets
+
+rec {
+  x = y;
+  y = 123;
+}.x
+
+# let-expressions
+
+let
+  x = "foo";
+  y = "bar";
+in x + y
+
+let x = 123; in
+{ inherit x;
+  y = 456;
+}
+
+# functions
+
+pattern: body
+
+let negate = x: !x;
+    concat = x: y: x + y;
+in if negate true then concat "foo" "bar" else ""
+
+map (concat "foo") [ "bar" "bla" "abc" ]
+
+{ x, y, z }: z + y + x
+
+{ x, y, z, ... }: z + y + x
+
+{ x, y ? "foo", z ? "bar" }: z + y + x
+
+args@{ x, y, z, ... }: z + y + x + args.a
+
+let concat = { x, y }: x + y;
+in concat { x = "foo"; y = "bar"; }
+
+let add = { __functor = self: x: x + self.x; };
+    inc = add // { x = 1; };
+in inc 1
+
+# conditionals
+
+if e1 then e2 else e3
+
+# assertions
+
+assert e1; e2
+
+# with-expressions
+
+with e1; e2
+
+let as = { x = "foo"; y = "bar"; };
+in with as; x + y
+
+with (import ./definitions.nix); ...
+
+# Operators
 # https://nixos.org/nix/manual/#sec-language-operators
+
 e . attrpath or def
 
 e1 e2

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -231,7 +231,7 @@ stdenv.mkDerivation { # 2
     '';
   };
   builder = ./builder.sh; # 4
-  src = fetchurl { 5
+  src = fetchurl { # 5
     url = ftp://ftp.nluug.nl/pub/gnu/hello/hello-2.1.1.tar.gz;
     md5 = "70c9ccf9fac07f762c24f2df2290784d";
   };

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -229,7 +229,7 @@ stdenv.mkDerivation { # 2
   ";
   meta = {
     # 3: Indented string
-    description = ''
+    description = '' # part of the string
     A contrived example of a Nix expression, suitable for testing the lexer for
     Rouge.
     '';

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -1,0 +1,12 @@
+# See https://nixos.org/nix/manual/#sec-expression-syntax
+{ stdenv, fetchurl, perl }: // 1
+
+stdenv.mkDerivation { // 2
+  name = "hello-2.1.1"; // 3
+  builder = ./builder.sh; // 4
+  src = fetchurl { 5
+    url = ftp://ftp.nluug.nl/pub/gnu/hello/hello-2.1.1.tar.gz;
+    md5 = "70c9ccf9fac07f762c24f2df2290784d";
+  };
+  inherit perl; // 6
+}

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -1,8 +1,44 @@
-# See https://nixos.org/nix/manual/#sec-expression-syntax
+// inline comments
+// another inline comment
+
+// inline comment after empty line
+
+  // inline comment after white-space
+
+12 // EOL comment
+
+/* multi-line
+ * comment
+ */
+
+0
+
+47
+
+true
+
+false
+
+"this is a string"
+
+"interpolated ${x}"
+
+binding
+
 { stdenv, fetchurl, perl }: // 1
 
 stdenv.mkDerivation { // 2
-  name = "hello-2.1.1"; // 3
+  name = "hello-2.1.1"; // 1: String
+  // 2: Multiline string
+  configureFlags  = "
+  ";
+  meta = {
+    // 3: Indented string
+    description = ''
+    A contrived example of a Nix expression, suitable for testing the lexer for
+    Rouge.
+    '';
+  };
   builder = ./builder.sh; // 4
   src = fetchurl { 5
     url = ftp://ftp.nluug.nl/pub/gnu/hello/hello-2.1.1.tar.gz;

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -101,6 +101,13 @@ e1 || e2
 
 e1 -> e2
 
+with e1; e2
+
+let as = { x = "foo"; y = "bar"; };
+in with as; x + y
+
+with (import ./definitions.nix); ...
+
 { stdenv, fetchurl, perl }: // 1
 
 stdenv.mkDerivation { // 2

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -76,7 +76,28 @@ stdenv.mkDerivation {
     '';
 }
 
-// https://nixos.org/nix/manual/#sec-language-operators
+# paths
+
+/bin/sh
+
+./builder.sh
+
+../xyzzy/fnord.nix
+
+~/foo
+
+local/file
+
+https://nixos.org/nixos/manual/index.html
+git+https://nixos.org/nixos/manual/index.html
+
+file:///tmp/nixos
+
+~ # not a path
+
+/ # not a path
+
+# https://nixos.org/nix/manual/#sec-language-operators
 e . attrpath or def
 
 e1 e2

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -15,15 +15,23 @@
 
 47
 
+null
+
 true
 
 false
+
+ab = q
+
+42 == 24
+
+12 + 3 / 2 * 1
 
 "this is a string"
 
 "interpolated ${x}"
 
-binding
+reference
 
 _12 = "twelve"
 
@@ -67,6 +75,31 @@ stdenv.mkDerivation {
       ${if enableBar then "cp bar $out/bin" else ""}
     '';
 }
+
+// https://nixos.org/nix/manual/#sec-language-operators
+e . attrpath or def
+
+e1 e2
+
+e ? attrpath
+
+e1 ++ e2
+
+e1 + e2
+
+! e
+
+e1 // e2
+
+e1 == e2
+
+e1 != e2
+
+e1 && e2
+
+e1 || e2
+
+e1 -> e2
 
 { stdenv, fetchurl, perl }: // 1
 


### PR DESCRIPTION
Basic highlighting for the [:snowflake: Nix expression language](https://nixos.org/nix/manual/#ch-expression-language).

Just adding it because I want syntax highlighting for Nix code on Github pages :wink: