### PR TITLE
Speed up `shebang?` check

### DIFF
--- a/lib/rouge/text_analyzer.rb
+++ b/lib/rouge/text_analyzer.rb
@@ -15,6 +15,7 @@ module Rouge
     # This normalizes things so that `text.shebang?('bash')` will detect
     # `#!/bash`, '#!/bin/bash', '#!/usr/bin/env bash', and '#!/bin/bash -x'
     def shebang?(match)
+      return false unless shebang
       match = /\b#{match}(\s|$)/
       match === shebang
     end


### PR DESCRIPTION
It's very common that `shebang` is `nil`. When this happens we can avoid the allocation of a regex and the regex comparison by exiting early. In a Jekyll app this change brought `Rouge::TextAnalyzer#shebang` from the off of most time consuming methods as indicated by stackprof:

Before patch

```
$ stackprof tmp/stackprof.dump
==================================
  Mode: wall(1000)
  Samples: 5128 (0.37% miss rate)
  GC: 908 (17.71%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       204   (4.0%)         204   (4.0%)     Rouge::TextAnalyzer#shebang
       170   (3.3%)         164   (3.2%)     Set#each
       331   (6.5%)         157   (3.1%)     Set#initialize
       932  (18.2%)         153   (3.0%)     Rouge::Guessers::Source#filter
       150   (2.9%)         149   (2.9%)     Set#add
       478   (9.3%)         143   (2.8%)     Kramdown::Parser::Kramdown#parse_spans
       102   (2.0%)         102   (2.0%)     #<Module:0x007fa438195d28>.sanitized_path
       422   (8.2%)         101   (2.0%)     Rouge::RegexLexer#step
        92   (1.8%)          90   (1.8%)     Jekyll::Tags::IncludeTag#read_file
        95   (1.9%)          77   (1.5%)     Addressable::URI.encode_component
        77   (1.5%)          77   (1.5%)     Rouge::Lexer.all
        69   (1.3%)          69   (1.3%)     Kramdown::Utils::StringScanner#current_line_number
        63   (1.2%)          63   (1.2%)     Jekyll::LiquidRenderer::File#initialize
        62   (1.2%)          62   (1.2%)     #<Module:0x007fa43817e998>.lookup_unicode_composition
        62   (1.2%)          62   (1.2%)     Liquid::Lexer#tokenize
        61   (1.2%)          61   (1.2%)     Rouge::Lexers::ObjectiveC.analyze_text
        58   (1.1%)          58   (1.1%)     Liquid::Tokenizer#tokenize
        50   (1.0%)          50   (1.0%)     Rouge::Lexer.tag
        57   (1.1%)          49   (1.0%)     Liquid::VariableLookup#initialize
        47   (0.9%)          47   (0.9%)     Kramdown::Utils::StringScanner#pos=
       147   (2.9%)          45   (0.9%)     #<Module:0x007fa43817e998>.unicode_compose_pair
        44   (0.9%)          44   (0.9%)     Rouge::Lexer.aliases
       645  (12.6%)          42   (0.8%)     Kramdown::Parser::Kramdown#parse_blocks
       426   (8.3%)          41   (0.8%)     Liquid::Context#evaluate
      5571 (108.6%)          40   (0.8%)     Liquid::BlockBody#render
        37   (0.7%)          37   (0.7%)     Jekyll::Document#data
        37   (0.7%)          37   (0.7%)     Liquid::Lexer#initialize
        85   (1.7%)          36   (0.7%)     Liquid::Expression.parse
      2843  (55.4%)          35   (0.7%)     Jekyll::LiquidRenderer::File#measure_time
        36   (0.7%)          34   (0.7%)     Kramdown::Utils::Html#escape_html
```

After patch:

```
$ stackprof tmp/stackprof.dump
==================================
  Mode: wall(1000)
  Samples: 4926 (0.50% miss rate)
  GC: 946 (19.20%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       200   (4.1%)         192   (3.9%)     Set#each
       343   (7.0%)         173   (3.5%)     Set#initialize
       528  (10.7%)         146   (3.0%)     Kramdown::Parser::Kramdown#parse_spans
       146   (3.0%)         140   (2.8%)     Set#add
       522  (10.6%)         128   (2.6%)     Rouge::Guessers::Source#filter
       452   (9.2%)         102   (2.1%)     Rouge::RegexLexer#step
        94   (1.9%)          94   (1.9%)     #<Module:0x007fc583b4d958>.sanitized_path
        91   (1.8%)          90   (1.8%)     Rouge::Lexer.all
        75   (1.5%)          72   (1.5%)     Jekyll::Tags::IncludeTag#read_file
        71   (1.4%)          71   (1.4%)     Rouge::Lexers::ObjectiveC.analyze_text
        73   (1.5%)          63   (1.3%)     Addressable::URI.encode_component
        61   (1.2%)          61   (1.2%)     Rouge::Lexer.tag
        60   (1.2%)          60   (1.2%)     Liquid::Tokenizer#tokenize
        60   (1.2%)          60   (1.2%)     Kramdown::Utils::StringScanner#current_line_number
        57   (1.2%)          57   (1.2%)     #<Module:0x007fc583b36730>.lookup_unicode_composition
       679  (13.8%)          57   (1.2%)     Kramdown::Parser::Kramdown#parse_blocks
        53   (1.1%)          53   (1.1%)     Liquid::Lexer#tokenize
       154   (3.1%)          53   (1.1%)     #<Module:0x007fc583b36730>.unicode_compose_pair
        52   (1.1%)          52   (1.1%)     Jekyll::LiquidRenderer::File#initialize
       148   (3.0%)          47   (1.0%)     Addressable::URI#initialize
        45   (0.9%)          45   (0.9%)     Kramdown::Utils::StringScanner#pos=
       441   (9.0%)          41   (0.8%)     Liquid::BlockBody#parse
        40   (0.8%)          40   (0.8%)     Jekyll::URL#sanitize_url
        44   (0.9%)          39   (0.8%)     Liquid::VariableLookup#initialize
        38   (0.8%)          38   (0.8%)     Rouge::Lexer.aliases
      5315 (107.9%)          34   (0.7%)     Liquid::BlockBody#render
        85   (1.7%)          31   (0.6%)     Kramdown::Parser::Kramdown#parse_block_html
        29   (0.6%)          29   (0.6%)     #<Module:0x007fc583b36730>.lookup_unicode_combining_class
        68   (1.4%)          29   (0.6%)     Liquid::Expression.parse
        27   (0.5%)          27   (0.5%)     Liquid::Lexer#initialize
```


We could get further speed bumps by using `Regexp#match?` with Ruby 2.4 but the only way to do that would be to introduce a duplicate method and feature flip between them depending on the version of Ruby used.