### PR TITLE
Simplify Formatters:Terminal256's theme detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Builtin formatters include:
     * `line_numbers: false` - use an HTMLTable formatter
     * `wrap: true` - use an HTMLPygments wrapper
     * `css_class: 'codehilite'` - a CSS class to use for the pygments wrapper
+* `Rouge::Formatters::Terminal256.new(theme)`
+  * `theme` must be an instnce of `Rouge::Theme`, or a `Hash` structure with `:theme` entry
 
 #### Lexer options
 ##### debug: false

--- a/lib/rouge/formatters/terminal256.rb
+++ b/lib/rouge/formatters/terminal256.rb
@@ -9,17 +9,13 @@ module Rouge
       # @private
       attr_reader :theme
 
-      # @argument theme
+      # @param [Hash,Rouge::Theme] theme
       #   the theme to render with.
-      def initialize(theme='thankful_eyes')
-        if theme.is_a?(Class) && theme < Rouge::Theme
-          @theme = theme.new
-        elsif theme.is_a?(Rouge::Theme)
+      def initialize(theme = Themes::ThankfulEyes.new)
+        if theme.is_a?(Rouge::Theme)
           @theme = theme
-        elsif theme.is_a?(String)
-          @theme = Rouge::Theme.find(theme).new
         elsif theme.is_a?(Hash)
-          @theme = theme[:theme] || Themes::ThankfulEyes
+          @theme = theme[:theme] || Themes::ThankfulEyes.new
         else
           raise ArgumentError, "invalid theme: #{theme.inspect}"
         end

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -1,0 +1,9 @@
+describe Rouge::Formatter do
+  it 'finds terminal256' do
+    assert { Rouge::Formatter.find('terminal256') }
+  end
+
+  it 'is found by Rouge.highlight' do
+    assert { Rouge.highlight('puts "Hello"', 'ruby', 'terminal256') }
+  end
+end


### PR DESCRIPTION
Amends #735 to make the code simple.

Also adds tests and docs.