### PR TITLE
Rouge::Guessers::Modeline#filter: reduce object allocations

### DIFF
--- a/lib/rouge/guessers/modeline.rb
+++ b/lib/rouge/guessers/modeline.rb
@@ -33,9 +33,10 @@ module Rouge
         search_space = (lines.first(@lines) + lines.last(@lines)).join("\n")
 
         matches = MODELINES.map { |re| re.match(search_space) }.compact
+        return lexers unless matches.any?
+        
         match_set = Set.new(matches.map { |m| m[1] })
-
-        lexers.select { |l| (Set.new([l.tag] + l.aliases) & match_set).any? }
+        lexers.select { |l| match_set.include?(l.tag) || l.aliases.any? { |a| match_set.include?(a) } }
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/jneen/rouge/issues/755.

In "Ruby Performance Optimization" (c 2015), the author has a big ol' table of iterator methods and how many extra `T_NODE` objects they create. `any?` creates `2` for Enumerable, Array, and Range, whereas `select` creates `0` for Enumerable, `1` for Array, and `0` for Range. So we'd want to avoid using `any?` inside of any loops.

What do you think?