### PR TITLE
Refactor: Use manual disambiguators for shared filenames

### DIFF
--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -41,15 +41,6 @@ load load_dir.join('rouge/util.rb')
 load load_dir.join('rouge/text_analyzer.rb')
 load load_dir.join('rouge/token.rb')
 
-load load_dir.join('rouge/guesser.rb')
-load load_dir.join('rouge/guessers/util.rb')
-load load_dir.join('rouge/guessers/glob_mapping.rb')
-load load_dir.join('rouge/guessers/modeline.rb')
-load load_dir.join('rouge/guessers/filename.rb')
-load load_dir.join('rouge/guessers/mimetype.rb')
-load load_dir.join('rouge/guessers/source.rb')
-load load_dir.join('rouge/guessers/disambiguation.rb')
-
 load load_dir.join('rouge/lexer.rb')
 load load_dir.join('rouge/regex_lexer.rb')
 load load_dir.join('rouge/template_lexer.rb')
@@ -58,6 +49,15 @@ lexers_dir = load_dir.join('rouge/lexers')
 Dir.glob(lexers_dir.join('*.rb')).each do |f|
   Rouge::Lexers.load_lexer(Pathname.new(f).relative_path_from(lexers_dir).to_s)
 end
+
+load load_dir.join('rouge/guesser.rb')
+load load_dir.join('rouge/guessers/util.rb')
+load load_dir.join('rouge/guessers/glob_mapping.rb')
+load load_dir.join('rouge/guessers/modeline.rb')
+load load_dir.join('rouge/guessers/filename.rb')
+load load_dir.join('rouge/guessers/mimetype.rb')
+load load_dir.join('rouge/guessers/source.rb')
+load load_dir.join('rouge/guessers/disambiguation.rb')
 
 load load_dir.join('rouge/formatter.rb')
 load load_dir.join('rouge/formatters/html.rb')

--- a/lib/rouge.rb
+++ b/lib/rouge.rb
@@ -42,11 +42,13 @@ load load_dir.join('rouge/text_analyzer.rb')
 load load_dir.join('rouge/token.rb')
 
 load load_dir.join('rouge/guesser.rb')
+load load_dir.join('rouge/guessers/util.rb')
 load load_dir.join('rouge/guessers/glob_mapping.rb')
 load load_dir.join('rouge/guessers/modeline.rb')
 load load_dir.join('rouge/guessers/filename.rb')
 load load_dir.join('rouge/guessers/mimetype.rb')
 load load_dir.join('rouge/guessers/source.rb')
+load load_dir.join('rouge/guessers/disambiguation.rb')
 
 load load_dir.join('rouge/lexer.rb')
 load load_dir.join('rouge/regex_lexer.rb')

--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -1,0 +1,73 @@
+module Rouge
+  module Guessers
+    class Disambiguation < Guesser
+      include Util
+
+      def initialize(filename, source)
+        @filename = File.basename(filename)
+        @source = source
+      end
+
+      def filter(lexers)
+        return lexers if lexers.size == 1
+        return lexers if lexers.size == Lexer.all.size
+
+        @analyzer = TextAnalyzer.new(get_source(@source))
+
+        self.class.disambiguators.each do |disambiguator|
+          next unless disambiguator.match?(@filename)
+
+          filtered = disambiguator.decide!(self)
+          return filtered if filtered
+        end
+
+        return lexers
+      end
+
+      def contains?(text)
+        return @analyzer.include?(text)
+      end
+
+      def matches?(re)
+        return !!(@analyzer =~ re)
+      end
+
+      @disambiguators = []
+      def self.disambiguate(pattern, &decider)
+        @disambiguators << Disambiguator.new(pattern, &decider)
+      end
+
+      def self.disambiguators
+        @disambiguators
+      end
+
+      class Disambiguator
+        include Util
+
+        def initialize(pattern, &decider)
+          @pattern = pattern
+          @decider = decider
+        end
+
+        def decide!(guesser)
+          out = guesser.instance_eval(&@decider)
+          case out
+          when Array then out
+          when nil then nil
+          else [out]
+          end
+        end
+
+        def match?(filename)
+          test_glob(@pattern, filename)
+        end
+      end
+
+      disambiguate '*.pl' do
+        next Lexers::Perl if contains?('my $')
+        next Lexers::Prolog if contains?(':-')
+        next Lexers::Prolog if matches?(/\A\w+(\(\w+\,\s*\w+\))*\./)
+      end
+    end
+  end
+end

--- a/lib/rouge/guessers/glob_mapping.rb
+++ b/lib/rouge/guessers/glob_mapping.rb
@@ -3,6 +3,8 @@ module Rouge
     # This class allows for custom behavior
     # with glob -> lexer name mappings
     class GlobMapping < Guesser
+      include Util
+
       def self.by_pairs(mapping, filename)
         glob_map = {}
         mapping.each do |(glob, lexer_name)|
@@ -29,7 +31,7 @@ module Rouge
 
         collect_best(lexers) do |lexer|
           score = (@glob_map[lexer.name] || []).map do |pattern|
-            if test_pattern(pattern, basename)
+            if test_glob(pattern, basename)
               # specificity is better the fewer wildcards there are
               -pattern.scan(/[*?\[]/).size
             end
@@ -38,9 +40,6 @@ module Rouge
       end
 
       private
-      def test_pattern(pattern, path)
-        File.fnmatch?(pattern, path, File::FNM_DOTMATCH | File::FNM_CASEFOLD)
-      end
     end
   end
 end

--- a/lib/rouge/guessers/glob_mapping.rb
+++ b/lib/rouge/guessers/glob_mapping.rb
@@ -38,8 +38,6 @@ module Rouge
           end.compact.min
         end
       end
-
-      private
     end
   end
 end

--- a/lib/rouge/guessers/source.rb
+++ b/lib/rouge/guessers/source.rb
@@ -13,20 +13,17 @@ module Rouge
         # we've already filtered to 1
         return lexers if lexers.size == 1
 
-        # If we're filtering against *all* lexers, we only use confident return
-        # values from analyze_text.  But if we've filtered down already, we can trust
-        # the analysis more.
-        threshold = lexers.size < 10 ? 0 : 0.5
-
         source_text = get_source(@source)
 
         Lexer.assert_utf8!(source_text)
 
         source_text = TextAnalyzer.new(source_text)
 
-        collect_best(lexers, threshold: threshold) do |lexer|
+        collect_best(lexers) do |lexer|
           next unless lexer.methods(false).include? :analyze_text
-          lexer.analyze_text(source_text)
+          score = lexer.analyze_text(source_text)
+          raise "invalid score for #{lexer.tag}" unless [nil, 0, 1].include?(score)
+          score
         end
       end
     end

--- a/lib/rouge/guessers/source.rb
+++ b/lib/rouge/guessers/source.rb
@@ -20,10 +20,8 @@ module Rouge
         source_text = TextAnalyzer.new(source_text)
 
         collect_best(lexers) do |lexer|
-          next unless lexer.methods(false).include? :analyze_text
-          score = lexer.analyze_text(source_text)
-          raise "invalid score for #{lexer.tag}" unless [nil, 0, 1].include?(score)
-          score
+          next unless lexer.methods(false).include? :detect?
+          lexer.detect?(source_text) ? 1 : nil
         end
       end
     end

--- a/lib/rouge/guessers/source.rb
+++ b/lib/rouge/guessers/source.rb
@@ -1,6 +1,8 @@
 module Rouge
   module Guessers
     class Source < Guesser
+      include Util
+
       attr_reader :source
       def initialize(source)
         @source = source
@@ -16,14 +18,7 @@ module Rouge
         # the analysis more.
         threshold = lexers.size < 10 ? 0 : 0.5
 
-        source_text = case @source
-        when String
-          @source
-        when ->(s){ s.respond_to? :read }
-          @source.read
-        else
-          raise 'invalid source'
-        end
+        source_text = get_source(@source)
 
         Lexer.assert_utf8!(source_text)
 

--- a/lib/rouge/guessers/util.rb
+++ b/lib/rouge/guessers/util.rb
@@ -1,0 +1,20 @@
+module Rouge
+  module Guessers
+    module Util
+      def test_glob(pattern, path)
+        File.fnmatch?(pattern, path, File::FNM_DOTMATCH | File::FNM_CASEFOLD)
+      end
+
+      def get_source(source)
+        case source
+        when String
+          source
+        when ->(s){ s.respond_to? :read }
+          source.read
+        else
+          raise 'invalid source'
+        end
+      end
+    end
+  end
+end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -149,7 +149,7 @@ module Rouge
       #   fails, will be searched for shebangs, <!DOCTYPE ...> tags, and
       #   other hints.
       #
-      # @see Lexer.analyze_text
+      # @see Lexer.detect?
       # @see Lexer.guesses
       def guess(info={})
         lexers = guesses(info)
@@ -426,16 +426,14 @@ module Rouge
 
     # @abstract
     #
-    # Return a number between 0 and 1 indicating the likelihood that
-    # the text given should be lexed with this lexer.  The default
-    # implementation returns 0.  Values under 0.5 will only be used
-    # to disambiguate filename or mimetype matches.
+    # Return true if there is an in-text indication (such as a shebang
+    # or DOCTYPE declaration) that this lexer should be used.
     #
     # @param [TextAnalyzer] text
     #   the text to be analyzed, with a couple of handy methods on it,
     #   like {TextAnalyzer#shebang?} and {TextAnalyzer#doctype?}
-    def self.analyze_text(text)
-      0
+    def self.detect?(text)
+      false
     end
   end
 

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -133,6 +133,7 @@ module Rouge
         guessers << Guessers::Filename.new(filename) if filename
         guessers << Guessers::Modeline.new(source) if source
         guessers << Guessers::Source.new(source) if source
+        guessers << Guessers::Disambiguation.new(filename, source) if source && filename
 
         Guesser.guess(guessers, Lexer.all)
       end

--- a/lib/rouge/lexers/apiblueprint.rb
+++ b/lib/rouge/lexers/apiblueprint.rb
@@ -11,10 +11,6 @@ module Rouge
       filenames '*.apib'
       mimetypes 'text/vnd.apiblueprint'
 
-      def self.analyze_text(text)
-        return 1 if text.start_with?('FORMAT: 1A\n')
-      end
-
       prepend :root do
         # Metadata
         rule(/(\S+)(:\s*)(.*)$/) do

--- a/lib/rouge/lexers/awk.rb
+++ b/lib/rouge/lexers/awk.rb
@@ -10,8 +10,8 @@ module Rouge
       filenames '*.awk'
       mimetypes 'application/x-awk'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang?('awk')
+      def self.detect?(text)
+        return true if text.shebang?('awk')
       end
 
       id = /[$a-zA-Z_][a-zA-Z0-9_]*/

--- a/lib/rouge/lexers/biml.rb
+++ b/lib/rouge/lexers/biml.rb
@@ -8,8 +8,8 @@ module Rouge
       tag 'biml'
       filenames '*.biml'
 
-      def self.analyze_text(text)
-        return 1 if text =~ /<\s*Biml\b/
+      def self.detect?(text)
+        return true if text =~ /<\s*Biml\b/
       end
 
       prepend :root do

--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -55,11 +55,6 @@ module Rouge
         )
       end
 
-      # high priority for filename matches
-      def self.analyze_text(*)
-        0.3
-      end
-
       def self.builtins
         @builtins ||= []
       end

--- a/lib/rouge/lexers/coffeescript.rb
+++ b/lib/rouge/lexers/coffeescript.rb
@@ -11,8 +11,8 @@ module Rouge
       title "CoffeeScript"
       desc 'The Coffeescript programming language (coffeescript.org)'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'coffee'
+      def self.detect?(text)
+        return true if text.shebang? 'coffee'
       end
 
       def self.keywords

--- a/lib/rouge/lexers/coq.rb
+++ b/lib/rouge/lexers/coq.rb
@@ -8,10 +8,6 @@ module Rouge
       tag 'coq'
       mimetypes 'text/x-coq'
 
-      def self.analyze_text(text)
-        return 0.3 if text.include? "Require"
-      end
-
       def self.gallina
         @gallina ||= Set.new %w(
           as fun if in let match then else return end Type Set Prop

--- a/lib/rouge/lexers/diff.rb
+++ b/lib/rouge/lexers/diff.rb
@@ -10,9 +10,9 @@ module Rouge
       mimetypes 'text/x-diff', 'text/x-patch'
 
       def self.analyze_text(text)
-        return 1   if text.start_with?('Index: ')
-        return 1   if text.start_with?('diff ')
-        return 0.9 if text.start_with?('--- ')
+        return 1 if text.start_with?('Index: ')
+        return 1 if text =~ %r(\Adiff[^\n]*?\ba/[^\n]*\bb/)
+        return 1 if text =~ /(---|[+][+][+]).*?\n(---|[+][+][+])/
       end
 
       state :root do

--- a/lib/rouge/lexers/diff.rb
+++ b/lib/rouge/lexers/diff.rb
@@ -9,10 +9,10 @@ module Rouge
       filenames '*.diff', '*.patch'
       mimetypes 'text/x-diff', 'text/x-patch'
 
-      def self.analyze_text(text)
-        return 1 if text.start_with?('Index: ')
-        return 1 if text =~ %r(\Adiff[^\n]*?\ba/[^\n]*\bb/)
-        return 1 if text =~ /(---|[+][+][+]).*?\n(---|[+][+][+])/
+      def self.detect?(text)
+        return true if text.start_with?('Index: ')
+        return true if text =~ %r(\Adiff[^\n]*?\ba/[^\n]*\bb/)
+        return true if text =~ /(---|[+][+][+]).*?\n(---|[+][+][+])/
       end
 
       state :root do

--- a/lib/rouge/lexers/digdag.rb
+++ b/lib/rouge/lexers/digdag.rb
@@ -11,10 +11,6 @@ module Rouge
 
       mimetypes 'application/x-digdag'
 
-      def self.analyze_text(text)
-        # disable YAML.analyze_text
-      end
-
       # http://docs.digdag.io/operators.html
       # as of digdag v0.9.10
       KEYWORD_PATTERN = Regexp.union(%w(

--- a/lib/rouge/lexers/erb.rb
+++ b/lib/rouge/lexers/erb.rb
@@ -11,10 +11,6 @@ module Rouge
 
       filenames '*.erb', '*.erubis', '*.rhtml', '*.eruby'
 
-      def self.analyze_text(text)
-        return 0.4 if text =~ /<%.*%>/
-      end
-
       def initialize(opts={})
         @ruby_lexer = Ruby.new(opts)
 

--- a/lib/rouge/lexers/erlang.rb
+++ b/lib/rouge/lexers/erlang.rb
@@ -11,10 +11,6 @@ module Rouge
 
       mimetypes 'text/x-erlang', 'application/x-erlang'
 
-      def self.analyze_text(text)
-        return 0.3 if text =~ /^-module[(]\w+[)][.]/
-      end
-
       keywords = %w(
         after begin case catch cond end fun if
         let of query receive try when

--- a/lib/rouge/lexers/factor.rb
+++ b/lib/rouge/lexers/factor.rb
@@ -9,8 +9,8 @@ module Rouge
       filenames '*.factor'
       mimetypes 'text/x-factor'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'factor'
+      def self.detect?(text)
+        return true if text.shebang? 'factor'
       end
 
       def self.builtins

--- a/lib/rouge/lexers/gherkin.rb
+++ b/lib/rouge/lexers/gherkin.rb
@@ -12,8 +12,8 @@ module Rouge
       filenames '*.feature'
       mimetypes 'text/x-gherkin'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'cucumber'
+      def self.detect?(text)
+        return true if text.shebang? 'cucumber'
       end
 
       # self-modifying method that loads the keywords file

--- a/lib/rouge/lexers/go.rb
+++ b/lib/rouge/lexers/go.rb
@@ -11,10 +11,6 @@ module Rouge
 
       mimetypes 'text/x-go', 'application/x-go'
 
-      def self.analyze_text(text)
-        return 0
-      end
-
       # Characters
 
       WHITE_SPACE            = /[\s\t\r\n]+/

--- a/lib/rouge/lexers/groovy.rb
+++ b/lib/rouge/lexers/groovy.rb
@@ -11,8 +11,8 @@ module Rouge
 
       ws = %r((?:\s|//.*?\n|/[*].*?[*]/)+)
 
-      def self.analyze_text(text)
-        return 1 if text.shebang?(/groovy/)
+      def self.detect?(text)
+        return true if text.shebang?(/groovy/)
       end
 
       def self.keywords

--- a/lib/rouge/lexers/haml.rb
+++ b/lib/rouge/lexers/haml.rb
@@ -16,10 +16,6 @@ module Rouge
       filenames '*.haml'
       mimetypes 'text/x-haml'
 
-      def self.analyze_text(text)
-        return 0.1 if text.start_with? '!!!'
-      end
-
       option 'filters[filter_name]', 'Mapping of lexers to use for haml :filters'
       attr_reader :filters
       # @option opts :filters

--- a/lib/rouge/lexers/haskell.rb
+++ b/lib/rouge/lexers/haskell.rb
@@ -11,8 +11,8 @@ module Rouge
       filenames '*.hs'
       mimetypes 'text/x-haskell'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang?('runhaskell')
+      def self.detect?(text)
+        return true if text.shebang?('runhaskell')
       end
 
       reserved = %w(

--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -9,9 +9,9 @@ module Rouge
       filenames '*.htm', '*.html', '*.xhtml'
       mimetypes 'text/html', 'application/xhtml+xml'
 
-      def self.analyze_text(text)
-        return 1 if text.doctype?(/\bhtml\b/i)
-        return 1 if text =~ /<\s*html\b/
+      def self.detect?(text)
+        return true if text.doctype?(/\bhtml\b/i)
+        return true if text =~ /<\s*html\b/
       end
 
       start do

--- a/lib/rouge/lexers/idlang.rb
+++ b/lib/rouge/lexers/idlang.rb
@@ -10,12 +10,6 @@ module Rouge
       tag 'idlang'
       filenames '*.idl'
 
-      def self.analyze_text(text)
-        # Does there exist a statement that starts with 'pro' or
-        # 'function'?
-        return 0.4 if text =~ /^\s+(pro|function)\z/
-      end
-
       name = /[_A-Z]\w*/i
       kind_param = /(\d+|#{name})/
       exponent = /[dDeE][+-]\d+/

--- a/lib/rouge/lexers/ini.rb
+++ b/lib/rouge/lexers/ini.rb
@@ -11,10 +11,6 @@ module Rouge
       filenames '*.ini', '*.INI', '*.gitconfig'
       mimetypes 'text/x-ini'
 
-      def self.analyze_text(text)
-        return 0.1 if text =~ /\A\[[\w\-.]+\]\s*[\w\-]+=\w+/
-      end
-
       identifier = /[\w\-.]+/
 
       state :basic do

--- a/lib/rouge/lexers/io.rb
+++ b/lib/rouge/lexers/io.rb
@@ -9,8 +9,8 @@ module Rouge
       mimetypes 'text/x-iosrc'
       filenames '*.io'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'io'
+      def self.detect?(text)
+        return true if text.shebang? 'io'
       end
 
       def self.constants

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -18,7 +18,7 @@ module Rouge
       mimetypes 'application/javascript', 'application/x-javascript',
                 'text/javascript', 'text/x-javascript'
 
-      def self.analyze_text(text)
+      def self.detect?(text)
         return 1 if text.shebang?('node')
         return 1 if text.shebang?('jsc')
         # TODO: rhino, spidermonkey, etc

--- a/lib/rouge/lexers/julia.rb
+++ b/lib/rouge/lexers/julia.rb
@@ -10,8 +10,8 @@ module Rouge
       filenames '*.jl'
       mimetypes 'text/x-julia', 'application/x-julia'
 
-      def self.analyze_text(text)
-        1 if text.shebang? 'julia'
+      def self.detect?(text)
+        return true if text.shebang? 'julia'
       end
 
       BUILTINS            = /\b(?:

--- a/lib/rouge/lexers/lasso.rb
+++ b/lib/rouge/lexers/lasso.rb
@@ -14,9 +14,9 @@ module Rouge
 
       option :start_inline, 'Whether to start inline instead of requiring <?lasso or ['
 
-      def self.analyze_text(text)
-        return 1 if text.shebang?('lasso9')
-        return 1 if text =~ /\A.*?<\?(lasso(script)?|=)/
+      def self.detect?(text)
+        return true if text.shebang?('lasso9')
+        return true if text =~ /\A.*?<\?(lasso(script)?|=)/
       end
 
       def initialize(*)

--- a/lib/rouge/lexers/lasso.rb
+++ b/lib/rouge/lexers/lasso.rb
@@ -15,11 +15,8 @@ module Rouge
       option :start_inline, 'Whether to start inline instead of requiring <?lasso or ['
 
       def self.analyze_text(text)
-        rv = 0.0
-        rv += 1 if text.shebang?('lasso9')
-        rv += 0.4 if text =~ /<\?(lasso(script)?|=)|no_square_brackets|noprocess/i
-        rv += 0.2 if text =~ /define(_tag|_type|\s)/i
-        return rv
+        return 1 if text.shebang?('lasso9')
+        return 1 if text =~ /\A.*?<\?(lasso(script)?|=)/
       end
 
       def initialize(*)

--- a/lib/rouge/lexers/llvm.rb
+++ b/lib/rouge/lexers/llvm.rb
@@ -10,10 +10,6 @@ module Rouge
       filenames '*.ll'
       mimetypes 'text/x-llvm'
 
-      def self.analyze_text(text)
-        return 0.1 if text =~ /\A%\w+\s=\s/
-      end
-
       string = /"[^"]*?"/
       identifier = /([-a-zA-Z$._][-a-zA-Z$._0-9]*|#{string})/
 

--- a/lib/rouge/lexers/lua.rb
+++ b/lib/rouge/lexers/lua.rb
@@ -19,8 +19,8 @@ module Rouge
         super(opts)
       end
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'lua'
+      def self.detect?(text)
+        return true if text.shebang? 'lua'
       end
 
       def self.builtins

--- a/lib/rouge/lexers/make.rb
+++ b/lib/rouge/lexers/make.rb
@@ -10,10 +10,6 @@ module Rouge
       filenames '*.make', 'Makefile', 'makefile', 'Makefile.*', 'GNUmakefile'
       mimetypes 'text/x-makefile'
 
-      def self.analyze_text(text)
-        return 0.6 if text =~ /^\.PHONY:/
-      end
-
       bsd_special = %w(
         include undef error warning if else elif endif for endfor
       )

--- a/lib/rouge/lexers/matlab.rb
+++ b/lib/rouge/lexers/matlab.rb
@@ -10,10 +10,6 @@ module Rouge
       filenames '*.m'
       mimetypes 'text/x-matlab', 'application/x-matlab'
 
-      def self.analyze_text(text)
-        return 0.4 if text =~ /^\s*% / # % comments are a dead giveaway
-      end
-
       def self.keywords
         @keywords = Set.new %w(
           break case catch classdef continue else elseif end for function

--- a/lib/rouge/lexers/moonscript.rb
+++ b/lib/rouge/lexers/moonscript.rb
@@ -22,8 +22,8 @@ module Rouge
         @disabled_modules = list_option(:disabled_modules)
       end
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'moon'
+      def self.detect?(text)
+        return true if text.shebang? 'moon'
       end
 
       def builtins

--- a/lib/rouge/lexers/mosel.rb
+++ b/lib/rouge/lexers/mosel.rb
@@ -11,9 +11,9 @@ module Rouge
       filenames '*.mos'
 
       mimetypes 'text/x-mosel'
-      
-      def self.analyze_text(text)
-        return 1 if text =~ /^\s*(model|package)\s+/
+
+      def self.detect?(text)
+        return true if text =~ /^\s*(model|package)\s+/
       end
 
       id = /[a-zA-Z_][a-zA-Z0-9_]*/

--- a/lib/rouge/lexers/nasm.rb
+++ b/lib/rouge/lexers/nasm.rb
@@ -106,11 +106,6 @@ module Rouge
         )
       end
 
-      # high priority for filename matches
-      def self.analyze_text(*)
-        0.3
-      end
-
       def self.builtins
         @builtins ||= []
       end

--- a/lib/rouge/lexers/objective_c.rb
+++ b/lib/rouge/lexers/objective_c.rb
@@ -29,20 +29,6 @@ module Rouge
         @builtins ||= %w(YES NO nil)
       end
 
-      def self.analyze_text(text)
-        return 1 if text =~ /@(end|implementation|protocol|property)\b/
-
-        id = /[a-z$_][a-z0-9$_]*/i
-        return 0.4 if text =~ %r(
-          \[ \s* #{id} \s+
-          (?:
-            #{id} \s* \]
-            | #{id}? :
-          )
-        )x
-        return 0.4 if text.include? '@"'
-      end
-
       id = /[a-z$_][a-z0-9$_]*/i
 
       prepend :statements do

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -12,8 +12,8 @@ module Rouge
       filenames '*.pl', '*.pm'
       mimetypes 'text/x-perl', 'application/x-perl'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'perl'
+      def self.detect?(text)
+        return true if text.shebang? 'perl'
       end
 
       keywords = %w(

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -14,7 +14,6 @@ module Rouge
 
       def self.analyze_text(text)
         return 1 if text.shebang? 'perl'
-        return 0.4 if text.include? 'my $'
       end
 
       keywords = %w(

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -75,8 +75,8 @@ module Rouge
         )
       end
 
-      def self.analyze_text(text)
-        return 1 if text.shebang?('php')
+      def self.detect?(text)
+        return true if text.shebang?('php')
       end
 
       state :root do

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -77,8 +77,6 @@ module Rouge
 
       def self.analyze_text(text)
         return 1 if text.shebang?('php')
-        return 0.3 if /<\?(?!xml)/ =~ text
-        0
       end
 
       state :root do

--- a/lib/rouge/lexers/plist.rb
+++ b/lib/rouge/lexers/plist.rb
@@ -8,10 +8,6 @@ module Rouge
 
       mimetypes 'text/x-plist', 'application/x-plist'
 
-      def self.analyze_text(text)
-        return 0.6 if text.start_with?("// !$*UTF8*$!")
-      end
-
       state :whitespace do
         rule /\s+/, Text::Whitespace
       end

--- a/lib/rouge/lexers/praat.rb
+++ b/lib/rouge/lexers/praat.rb
@@ -10,8 +10,8 @@ module Rouge
 
       filenames '*.praat', '*.proc', '*.psc'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'praat'
+      def self.detect?(text)
+        return true if text.shebang? 'praat'
       end
 
       keywords = %w(

--- a/lib/rouge/lexers/prolog.rb
+++ b/lib/rouge/lexers/prolog.rb
@@ -10,11 +10,6 @@ module Rouge
       filenames '*.pro', '*.P', '*.prolog', '*.pl'
       mimetypes 'text/x-prolog'
 
-      def self.analyze_text(text)
-        return 0.1 if text =~ /\A\w+(\(\w+\,\s*\w+\))*\./
-        return 0.1 if text.include? ':-'
-      end
-
       state :basic do
         rule /\s+/, Text
         rule /^#.*/, Comment::Single

--- a/lib/rouge/lexers/properties.rb
+++ b/lib/rouge/lexers/properties.rb
@@ -10,10 +10,6 @@ module Rouge
       filenames '*.properties'
       mimetypes 'text/x-java-properties'
 
-      def self.analyze_text(text)
-        return 0.1 if text =~ /\A\[[\w.-]+\]\s*\w+=\w+/
-      end
-
       identifier = /[\w.-]+/
 
       state :basic do

--- a/lib/rouge/lexers/puppet.rb
+++ b/lib/rouge/lexers/puppet.rb
@@ -9,9 +9,9 @@ module Rouge
       aliases 'pp'
       filenames '*.pp'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'puppet-apply'
-        return 1 if text.shebang? 'puppet'
+      def self.detect?(text)
+        return true if text.shebang? 'puppet-apply'
+        return true if text.shebang? 'puppet'
       end
 
       def self.keywords

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -10,8 +10,8 @@ module Rouge
       filenames '*.py', '*.pyw', '*.sc', 'SConstruct', 'SConscript', '*.tac'
       mimetypes 'text/x-python', 'application/x-python'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang?(/pythonw?(3|2(\.\d)?)?/)
+      def self.detect?(text)
+        return true if text.shebang?(/pythonw?(3|2(\.\d)?)?/)
       end
 
       def self.keywords

--- a/lib/rouge/lexers/q.rb
+++ b/lib/rouge/lexers/q.rb
@@ -32,10 +32,6 @@ module Rouge
         ]
       end
 
-      def self.analyze_text(text)
-        return 0
-      end
-
       state :root do
         # q allows a file to start with a shebang
         rule /#!(.*?)$/, Comment::Preproc, :top

--- a/lib/rouge/lexers/r.rb
+++ b/lib/rouge/lexers/r.rb
@@ -43,8 +43,8 @@ module Rouge
         trigamma trunc unclass untracemem UseMethod xtfrm
       )
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'Rscript'
+      def self.detect?(text)
+        return true if text.shebang? 'Rscript'
       end
 
       state :root do

--- a/lib/rouge/lexers/racket.rb
+++ b/lib/rouge/lexers/racket.rb
@@ -9,11 +9,11 @@ module Rouge
       filenames '*.rkt', '*.rktd', '*.rktl'
       mimetypes 'text/x-racket', 'application/x-racket'
 
-      def self.analyze_text(text)
+      def self.detect?(text)
         text =~ /\A#lang\s*(.*?)$/
         lang_attr = $1
-        return nil unless lang_attr
-        return 1 if lang_attr =~ /racket|scribble/
+        return false unless lang_attr
+        return true if lang_attr =~ /racket|scribble/
       end
 
       def self.keywords

--- a/lib/rouge/lexers/racket.rb
+++ b/lib/rouge/lexers/racket.rb
@@ -10,9 +10,10 @@ module Rouge
       mimetypes 'text/x-racket', 'application/x-racket'
 
       def self.analyze_text(text)
-        text = text.strip
-        return 1 if text.start_with? '#lang racket'
-        return 0.6 if text =~ %r(\A#lang [a-z/-]+$)i
+        text =~ /\A#lang\s*(.*?)$/
+        lang_attr = $1
+        return nil unless lang_attr
+        return 1 if lang_attr =~ /racket|scribble/
       end
 
       def self.keywords

--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -13,8 +13,8 @@ module Rouge
 
       mimetypes 'text/x-ruby', 'application/x-ruby'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'ruby'
+      def self.detect?(text)
+        return true if text.shebang? 'ruby'
       end
 
       state :symbols do

--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -10,8 +10,8 @@ module Rouge
       filenames '*.rs'
       mimetypes 'text/x-rust'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'rustc'
+      def self.detect?(text)
+        return true if text.shebang? 'rustc'
       end
 
       def self.keywords

--- a/lib/rouge/lexers/sed.rb
+++ b/lib/rouge/lexers/sed.rb
@@ -10,8 +10,8 @@ module Rouge
       filenames '*.sed'
       mimetypes 'text/x-sed'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'sed'
+      def self.detect?(text)
+        return true if text.shebang? 'sed'
       end
 
       class Regex < RegexLexer

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -14,7 +14,7 @@ module Rouge
       mimetypes 'application/x-sh', 'application/x-shellscript'
 
       def self.analyze_text(text)
-        text.shebang?(/(ba|z|k)?sh/) ? 1 : 0
+        return 1 if text.shebang?(/(ba|z|k)?sh/)
       end
 
       KEYWORDS = %w(

--- a/lib/rouge/lexers/shell.rb
+++ b/lib/rouge/lexers/shell.rb
@@ -13,8 +13,8 @@ module Rouge
 
       mimetypes 'application/x-sh', 'application/x-shellscript'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang?(/(ba|z|k)?sh/)
+      def self.detect?(text)
+        return true if text.shebang?(/(ba|z|k)?sh/)
       end
 
       KEYWORDS = %w(

--- a/lib/rouge/lexers/smarty.rb
+++ b/lib/rouge/lexers/smarty.rb
@@ -10,17 +10,6 @@ module Rouge
       filenames '*.tpl', '*.smarty'
       mimetypes 'application/x-smarty', 'text/x-smarty'
 
-      def self.analyze_text(text)
-        rv = 0.0
-        rv += 0.15 if text =~ /\{if\s+.*?\}.*?\{\/if\}/
-        rv += 0.15 if text =~ /\{include\s+file=.*?\}/
-        rv += 0.15 if text =~ /\{foreach\s+.*?\}.*?\{\/foreach\}/
-        rv += 0.01 if text =~ /\{\$.*?\}/
-        return rv
-      end
-
-
-
       def self.builtins
         @builtins ||= %w(
           append assign block call capture config_load debug extends

--- a/lib/rouge/lexers/sml.rb
+++ b/lib/rouge/lexers/sml.rb
@@ -28,10 +28,6 @@ module Rouge
       id = /[\w']+/i
       symbol = %r([!%&$#/:<=>?@\\~`^|*+-]+)
 
-      def self.analyze_text(text)
-        return 0
-      end
-
       state :whitespace do
         rule /\s+/m, Text
         rule /[(][*]/, Comment, :comment

--- a/lib/rouge/lexers/tap.rb
+++ b/lib/rouge/lexers/tap.rb
@@ -9,10 +9,6 @@ module Rouge
 
       mimetypes 'text/x-tap', 'application/x-tap'
 
-      def self.analyze_text(text)
-        return 0
-      end
-
       state :root do
         # A TAP version may be specified.
         rule /^TAP version \d+\n/, Name::Namespace

--- a/lib/rouge/lexers/tcl.rb
+++ b/lib/rouge/lexers/tcl.rb
@@ -9,10 +9,10 @@ module Rouge
       filenames '*.tcl'
       mimetypes 'text/x-tcl', 'text/x-script.tcl', 'application/x-tcl'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'tclsh'
-        return 1 if text.shebang? 'wish'
-        return 1 if text.shebang? 'jimsh'
+      def self.detect?(text)
+        return true if text.shebang? 'tclsh'
+        return true if text.shebang? 'wish'
+        return true if text.shebang? 'jimsh'
       end
 
       KEYWORDS = %w(

--- a/lib/rouge/lexers/tex.rb
+++ b/lib/rouge/lexers/tex.rb
@@ -11,8 +11,8 @@ module Rouge
       filenames '*.tex', '*.aux', '*.toc', '*.sty', '*.cls'
       mimetypes 'text/x-tex', 'text/x-latex'
 
-      def self.analyze_text(text)
-        return 1 if text =~ /\A\s*\\(documentclass|input|documentstyle|relax|ProvidesPackage|ProvidesClass)/
+      def self.detect?(text)
+        return true if text =~ /\A\s*\\(documentclass|input|documentstyle|relax|ProvidesPackage|ProvidesClass)/
       end
 
       command = /\\([a-z]+|\s+|.)/i

--- a/lib/rouge/lexers/toml.rb
+++ b/lib/rouge/lexers/toml.rb
@@ -10,10 +10,6 @@ module Rouge
       filenames '*.toml'
       mimetypes 'text/x-toml'
 
-      def self.analyze_text(text)
-        return 0.1 if text =~ /\A\[[\w.]+\]\s*\w+\s*=\s*("\w+")+/
-      end
-
       identifier = /[\w.\S]+/
 
       state :basic do

--- a/lib/rouge/lexers/tulip.rb
+++ b/lib/rouge/lexers/tulip.rb
@@ -9,8 +9,8 @@ module Rouge
 
       mimetypes 'text/x-tulip', 'application/x-tulip'
 
-      def self.analyze_text(text)
-        return 1 if text.shebang? 'tulip'
+      def self.detect?(text)
+        return true if text.shebang? 'tulip'
       end
 
       id = /[a-z][\w-]*/i

--- a/lib/rouge/lexers/tulip.rb
+++ b/lib/rouge/lexers/tulip.rb
@@ -11,7 +11,6 @@ module Rouge
 
       def self.analyze_text(text)
         return 1 if text.shebang? 'tulip'
-        return 0
       end
 
       id = /[a-z][\w-]*/i

--- a/lib/rouge/lexers/turtle.rb
+++ b/lib/rouge/lexers/turtle.rb
@@ -12,29 +12,21 @@ module Rouge
         application/trig
       )
 
-      def self.analyze_text(text)
-        start = text[0..1000]
-        return 0.5 if start =~ %r(@prefix\b)
-        return 0.5 if start =~ %r(@base\b)
-        return 0.4 if start =~ %r(PREFIX\b)i
-        return 0.4 if start =~ %r(BASE\b)i
-      end
-
       state :root do
         rule /@base\b/, Keyword::Declaration
         rule /@prefix\b/, Keyword::Declaration
         rule /true\b/, Keyword::Constant
         rule /false\b/, Keyword::Constant
-        
+
         rule /""".*?"""/m, Literal::String
         rule /"([^"\\]|\\.)*"/, Literal::String
         rule /'''.*?'''/m, Literal::String
         rule /'([^'\\]|\\.)*'/, Literal::String
-        
+
         rule /#.*$/, Comment::Single
-        
+
         rule /@[^\s,.; ]+/, Name::Attribute
-        
+
         rule /[+-]?[0-9]+\.[0-9]*E[+-]?[0-9]+/, Literal::Number::Float
         rule /[+-]?\.[0-9]+E[+-]?[0-9]+/, Literal::Number::Float
         rule /[+-]?[0-9]+E[+-]?[0-9]+/, Literal::Number::Float
@@ -53,7 +45,7 @@ module Rouge
         rule /\[/, Punctuation
         rule /\]/, Punctuation
         rule /\^\^/, Punctuation
-        
+
         rule /<[^>]*>/, Name::Label
 
         rule /base\b/i, Keyword::Declaration
@@ -65,7 +57,6 @@ module Rouge
 
         rule /[^:;<>#\@"\(\).\[\]\{\} ]+:/, Name::Namespace
         rule /[^:;<>#\@"\(\).\[\]\{\} ]+/, Name
-        
       end
     end
   end

--- a/lib/rouge/lexers/vue.rb
+++ b/lib/rouge/lexers/vue.rb
@@ -15,10 +15,6 @@ module Rouge
         @js = Javascript.new(options)
       end
 
-      def self.analyze_text(text)
-        return 0
-      end
-
       def lookup_lang(lang)
         case lang
         when 'html' then HTML

--- a/lib/rouge/lexers/wollok.rb
+++ b/lib/rouge/lexers/wollok.rb
@@ -8,10 +8,6 @@ module Rouge
       tag 'wollok'
       filenames *%w(*.wlk *.wtest *.wpgm)
 
-      def self.analyze_text(_text)
-        0.3
-      end
-
       keywords = %w(new super return if else var const override constructor)
 
       entity_name = /[a-zA-Z][a-zA-Z0-9]*/

--- a/lib/rouge/lexers/xml.rb
+++ b/lib/rouge/lexers/xml.rb
@@ -15,10 +15,10 @@ module Rouge
         application/atom+xml
       )
 
-      def self.analyze_text(text)
-        return nil if text.doctype?(/html/)
-        return 1 if text =~ /\A<\?xml\b/
-        return 1 if text.doctype?
+      def self.detect?(text)
+        return false if text.doctype?(/html/)
+        return true if text =~ /\A<\?xml\b/
+        return true if text.doctype?
       end
 
       state :root do

--- a/lib/rouge/lexers/xml.rb
+++ b/lib/rouge/lexers/xml.rb
@@ -16,11 +16,9 @@ module Rouge
       )
 
       def self.analyze_text(text)
-        return 0.9 if text.doctype?
-        return 0.8 if text =~ /\A<\?xml\b/
-        start = text[0..1000]
-        return 0.6 if start =~ %r(<xml\b)
-        return 0.3 if start =~ %r(<.+?>.*?</.+?>)m
+        return nil if text.doctype?(/html/)
+        return 1 if text =~ /\A<\?xml\b/
+        return 1 if text.doctype?
       end
 
       state :root do

--- a/lib/rouge/lexers/yaml.rb
+++ b/lib/rouge/lexers/yaml.rb
@@ -10,9 +10,9 @@ module Rouge
       aliases 'yml'
       filenames '*.yaml', '*.yml'
 
-      def self.analyze_text(text)
+      def self.detect?(text)
         # look for the %YAML directive
-        return 1 if text =~ /\A\s*%YAML/m
+        return true if text =~ /\A\s*%YAML/m
       end
 
       SPECIAL_VALUES = Regexp.union(%w(true false null))

--- a/spec/lexers/apiblueprint_spec.rb
+++ b/spec/lexers/apiblueprint_spec.rb
@@ -7,9 +7,5 @@ describe Rouge::Lexers::APIBlueprint do
     it 'guesses by filename' do
       assert_guess :filename => 'foo.apib'
     end
-
-    it 'guesses by source' do
-      assert_guess :source => 'FORMAT: 1A\n\n# My API\n'
-    end
   end
 end

--- a/spec/lexers/make_spec.rb
+++ b/spec/lexers/make_spec.rb
@@ -17,10 +17,6 @@ describe Rouge::Lexers::Make do
     it 'guesses by mimetype' do
       assert_guess :mimetype => 'text/x-makefile'
     end
-
-    it 'guesses by source' do
-      assert_guess :source => '.PHONY: all'
-    end
   end
 
   describe 'lexing' do

--- a/spec/lexers/objective_c_spec.rb
+++ b/spec/lexers/objective_c_spec.rb
@@ -16,9 +16,8 @@ describe Rouge::Lexers::ObjectiveC do
     end
 
     it 'guesses by source' do
-      assert_guess :filename => 'foo.h', :source => '[foo bar: baz]'
       assert_guess :filename => 'foo.h', :source => '@"foo"'
-      assert_guess :source => '@implementation Foo'
+      assert_guess :filename => 'foo.h', :source => '@implementation Foo'
     end
   end
 end

--- a/spec/lexers/plist_spec.rb
+++ b/spec/lexers/plist_spec.rb
@@ -12,9 +12,5 @@ describe Rouge::Lexers::Plist do
       assert_guess :mimetype => 'text/x-plist'
       assert_guess :mimetype => 'application/x-plist'
     end
-
-    it 'guesses by source' do
-      assert_guess :source => "// !$*UTF8*$!\n{}"
-    end
   end
 end

--- a/spec/lexers/turtle_spec.rb
+++ b/spec/lexers/turtle_spec.rb
@@ -15,10 +15,5 @@ describe Rouge::Lexers::Turtle do
       assert_guess :mimetype => 'text/turtle'
       assert_guess :mimetype => 'application/trig'
     end
-
-    it 'guesses by source' do
-      assert_guess :source => '@base'
-      assert_guess :source => '@prefix'
-    end
   end
 end

--- a/spec/lexers/xml_spec.rb
+++ b/spec/lexers/xml_spec.rb
@@ -25,7 +25,6 @@ describe Rouge::Lexers::XML do
     end
 
     it 'guesses by source' do
-      assert_guess :source => '<xml></xml>'
       assert_guess :source => '<?xml version="1.0" encoding="utf-8"?>'
       assert_guess :source => '<!DOCTYPE xml>'
       deny_guess   :source => '<!DOCTYPE html>'

--- a/spec/plugins/redcarpet_spec.rb
+++ b/spec/plugins/redcarpet_spec.rb
@@ -33,11 +33,12 @@ foo=1
   it 'guesses' do
     result = markdown.render <<-mkd
 ``` guess
-<xml>an xml code block</xml>
+#!/usr/bin/env ruby
+puts "hello, world"
 ```
     mkd
 
-    assert { result.include?(%(<pre class="highlight xml"><code>)) }
+    assert { result.include?(%(<pre class="highlight ruby"><code>)) }
   end
 
   it 'passes options' do

--- a/tasks/lex.rake
+++ b/tasks/lex.rake
@@ -19,8 +19,8 @@ module Rouge
 
       mimetypes 'text/x-#{language}', 'application/x-#{language}'
 
-      def self.analyze_text(text)
-        return 0
+      def self.detect?(text)
+        false
       end
 
       state :root do

--- a/tasks/lex.rake
+++ b/tasks/lex.rake
@@ -19,6 +19,10 @@ module Rouge
 
       mimetypes 'text/x-#{language}', 'application/x-#{language}'
 
+      # a method to return true when the text unambiguously indicates
+      # this language (for things like shebangs and DOCTYPE declarations)
+      #
+      # Please remove this method if no such indication is possible.
       def self.detect?(text)
         false
       end


### PR DESCRIPTION
This PR removes the use of `analyze_text`'s numeric score interface, and adds a facility for specifying manual disambiguating cases. `analyze_text` has been renamed to `detect?`, which returns a boolean, and is only meant to detect unambiguous cases (like shebangs and doctype declarations).