### PR TITLE
Added Visual Studio and Delphi project file types to the XML lexer

### DIFF
--- a/lib/rouge/lexers/xml.rb
+++ b/lib/rouge/lexers/xml.rb
@@ -6,7 +6,18 @@ module Rouge
       title "XML"
       desc %q(<desc for="this-lexer">XML</desc>)
       tag 'xml'
-      filenames *%w(*.xml *.xsl *.rss *.xslt *.xsd *.wsdl *.svg)
+      filenames *%w(
+        *.xml
+        *.xsl
+        *.rss
+        *.xslt
+        *.xsd
+        *.wsdl
+        *.svg
+        *.csproj
+        *.vbproj
+        *.dproj
+      )
       mimetypes *%w(
         text/xml
         application/xml

--- a/spec/lexers/xml_spec.rb
+++ b/spec/lexers/xml_spec.rb
@@ -14,6 +14,9 @@ describe Rouge::Lexers::XML do
       assert_guess :filename => 'foo.xsd'
       assert_guess :filename => 'foo.wsdl'
       assert_guess :filename => 'foo.svg'
+      assert_guess :filename => 'foo.csproj'
+      assert_guess :filename => 'foo.vbproj'
+      assert_guess :filename => 'foo.dproj'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
Added the following file types to the XML lexer:
* `csproj`: Microsoft Visual Studio C# project file
* `vbproj`: Microsoft Visual Studio Visual Basic project file
* `dproj`: Embarcadero Delphi Project File

The content of these file types is standard XML.