### PR TITLE
add `rougify guess $file` subcommand

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -44,6 +44,7 @@ module Rouge
       yield %|	help		#{Help.desc}|
       yield %|	style		#{Style.desc}|
       yield %|	list		#{List.desc}|
+      yield %|	guess		#{Guess.desc}|
       yield %|	version		#{Version.desc}|
       yield %||
       yield %|See `rougify help <command>` for more info.|
@@ -97,6 +98,8 @@ module Rouge
         Style
       when 'list'
         List
+      when 'guess'
+        Guess
       end
     end
 
@@ -374,6 +377,43 @@ module Rouge
         end
       end
     end
+
+    class Guess < CLI
+      def self.desc
+        "guess the languages of file"
+      end
+
+      def self.parse(args)
+        new(input_file: args.shift)
+      end
+
+      attr_reader :input_file, :input_source
+
+      def initialize(opts)
+        input_file = opts[:input_file]
+        if input_file == '-' || input_file.nil?
+          @input_file = nil
+          @input_source = STDIN.read
+        else
+          @input_file = opts[:input_file]
+          @input_source = File.read(@input_file)
+        end
+      end
+
+      def lexers
+        Lexer.guesses(
+          filename: input_file,
+          source: input_source,
+        )
+      end
+
+      def run
+        lexers.each do |l|
+          puts "{ tag: #{l.tag.inspect}, title: #{l.title.inspect}, desc: #{l.desc.inspect} }"
+        end
+      end
+    end
+
 
   private_class_method
     def self.normalize_syntax(argv)


### PR DESCRIPTION
To test how `Lexer.guesses` works.

ex.

```shell
$ ruby -Ilib bin/rougify guess Gemfile
{ tag: "ruby", title: "Ruby", desc: "The Ruby programming language (ruby-lang.org)" }

$  echo '#!/usr/bin/env perl` | rougify guess
{ tag: "perl", title: "Perl", desc: "The Perl scripting language (perl.org)" }
```

Note that the output format may change.

ref. https://github.com/jneen/rouge/pull/763
