### PR TITLE
Refactor spec framework

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'bundler', '~> 1.15'
-gem 'rake', '~> 12.0'
+gem 'rake'
 
-gem 'minitest', '~> 4.0'
-gem 'wrong'
+gem 'minitest'
+gem 'minitest-power_assert'
 
 gem 'rubocop', '~> 0.49.1' if RUBY_VERSION >= '2.0.0'
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,10 @@ If you're here to implement a lexer for your awesome language, there's a good ch
 
 ### Run the tests
 
-You can test the core of Rouge simply by running `rake` (no `bundle exec` required).  It's also set up with `guard`, if you like.
+You can test the core of Rouge simply by running `rake` (no `bundle exec` required), or `rake spec TEST=spec/xxx_spec.rb`
+to run a single test file.
+
+It's also set up with `guard`, if you like.
 
 To test a lexer visually, run `rackup` from the root and go to `localhost:9292/#{some_lexer}` where `some_lexer` is the tag or an alias of a lexer you'd like to test.  If you add `?debug=1`, helpful debugging info will be printed on stdout.
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ Rake::TestTask.new(:spec) do |t|
   t.pattern = FileList['spec/**/*_spec.rb']
 end
 
-task :test => [:spec] # alias for m
+task :test => [:spec]
 
 task :doc do
   sh 'bundle exec yard'

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,16 @@
 require 'rake/clean'
 require 'pathname'
 require "bundler/gem_tasks"
+require "rake/testtask"
 
-task :spec do
-  spec_files = FileList.new(ENV['files'] || './spec/**/*_spec.rb')
-  switch_spec_files = spec_files.map { |x| "-r#{x}" }.join(' ')
-  sh "ruby -I./lib -r ./spec/spec_helper #{switch_spec_files} -e Minitest::Unit.autorun"
+Rake::TestTask.new(:spec) do |t|
+  t.libs << "lib"
+  t.ruby_opts << "-r./spec/spec_helper"
+  t.warning = false # TODO: true
+  t.pattern = FileList['spec/**/*_spec.rb']
 end
+
+task :test => [:spec] # alias for m
 
 task :doc do
   sh 'bundle exec yard'

--- a/spec/lexer_spec.rb
+++ b/spec/lexer_spec.rb
@@ -3,6 +3,14 @@
 describe Rouge::Lexer do
   include Support::Lexing
 
+  it 'guesses the lexer with Lexer.guess' do
+    assert { Rouge::Lexer.guess(filename: 'foo.rb').tag == 'ruby' }
+  end
+
+  it 'guesses lexers with Lexer.guesses' do
+    assert { Rouge::Lexer.guesses(filename: 'foo.pl').map { |c| c.tag }.sort == ['perl', 'prolog'].sort }
+  end
+
   it 'makes a simple lexer' do
     a_lexer = Class.new(Rouge::RegexLexer) do
       state :root do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,12 +3,9 @@
 require 'rubygems'
 require 'bundler'
 Bundler.require
-
 require 'rouge'
 require 'minitest/spec'
-require 'wrong/adapters/minitest'
-
-Wrong.config[:color] = true
+require 'minitest/autorun'
 
 Token = Rouge::Token
 

--- a/spec/support/guessing.rb
+++ b/spec/support/guessing.rb
@@ -25,10 +25,10 @@ module Support
 
       type ||= subject.class
 
-      deny { Rouge::Lexer.guess(info) == type }
+      refute { Rouge::Lexer.guess(info) == type }
       Rouge::Lexer.all.reverse!
 
-      deny { Rouge::Lexer.guess(info) == type }
+      refute { Rouge::Lexer.guess(info) == type }
       Rouge::Lexer.all.reverse!
     end
   end

--- a/spec/support/lexing.rb
+++ b/spec/support/lexing.rb
@@ -21,7 +21,7 @@ module Support
     end
 
     def deny_has_token(tokname, text, lexer=nil)
-      deny { filter_by_token(tokname, text, lexer).any? }
+      refute { filter_by_token(tokname, text, lexer).any? }
     end
 
     def assert_has_token(tokname, text, lexer=nil)


### PR DESCRIPTION
* Use `Rake::Testtask` instead of define test tasks by hand
* Use a new `minitest-power_assert` instead of `wrong` gem
* Update minitest; `deny` is no longer supported, use `refute` instead
* Add some tests