### PR TITLE
drop support for Ruby < 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 dist: trusty
 language: ruby
 rvm:
-  - "1.9.3"
   - "2.0"
   - "2.1"
   - "2.2"
@@ -15,4 +14,4 @@ bundler_args: --without development
 before_install: gem update bundler
 script:
   - bundle exec rake
-  - if ruby -e 'exit RUBY_VERSION >= "2.0.0"' ; then bundle exec rubocop ; fi
+  - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rake', '~> 12.0'
 gem 'minitest', '~> 4.0'
 gem 'wrong'
 
-gem 'rubocop', '~> 0.49.1' if RUBY_VERSION >= '2.0.0'
+gem 'rubocop', '~> 0.49.1'
 
 # don't try to install redcarpet under jruby
 gem 'redcarpet', :platforms => :ruby

--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
   s.files = Dir['Gemfile', 'LICENSE', 'rouge.gemspec', 'lib/**/*.rb', 'lib/**/*.yml', 'bin/rougify', 'lib/rouge/demos/*']
   s.executables = %w(rougify)
   s.licenses = ['MIT', 'BSD-2-Clause']
+  s.required_ruby_version = '>= 2.0'
 end


### PR DESCRIPTION
Ruby 2.0 is released at [2013](https://www.ruby-lang.org/en/news/2013/02/24/ruby-2-0-0-p0-is-released/) which has a lot of fascinating features like:

* keyword arguments (`def foo(bar: ...)`)
* The source code is assumed to be UTF-8 by default
* [lots of updates in standard libraries](https://docs.ruby-lang.org/en/2.1.0/NEWS-2_0_0.html)

Especially, I'd like to use keyword arguments.

I'll wait a week before merging this PR. Please vote down (:-1:) if you use Rouge on Ruby 1.9.3.