### PR TITLE
normalize input source

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -13,9 +13,9 @@ module Rouge
     def file
       case input
       when '-'
-        IO.new($stdin.fileno, 'r:utf-8')
+        IO.new($stdin.fileno, 'rt:bom|utf-8')
       when String
-        File.new(input, 'r:utf-8')
+        File.new(input, 'rt:bom|utf-8')
       when ->(i){ i.respond_to? :read }
         input
       end
@@ -390,14 +390,8 @@ module Rouge
       attr_reader :input_file, :input_source
 
       def initialize(opts)
-        input_file = opts[:input_file]
-        if input_file == '-' || input_file.nil?
-          @input_file = nil
-          @input_source = STDIN.read
-        else
-          @input_file = opts[:input_file]
-          @input_source = File.read(@input_file)
-        end
+        @input_file = opts[:input_file] || '-'
+        @input_source = FileReader.new(@input_file).read
       end
 
       def lexers

--- a/lib/rouge/guessers/modeline.rb
+++ b/lib/rouge/guessers/modeline.rb
@@ -1,6 +1,8 @@
 module Rouge
   module Guessers
     class Modeline < Guesser
+      include Util
+
       # [jneen] regexen stolen from linguist
       EMACS_MODELINE = /-\*-\s*(?:(?!mode)[\w-]+\s*:\s*(?:[\w+-]+)\s*;?\s*)*(?:mode\s*:)?\s*([\w+-]+)\s*(?:;\s*(?!mode)[\w-]+\s*:\s*[\w+-]+\s*)*;?\s*-\*-/i
 
@@ -25,10 +27,9 @@ module Rouge
         # don't bother reading the stream if we've already decided
         return lexers if lexers.size == 1
 
-        source_text = @source
-        source_text = source_text.read if source_text.respond_to? :read
+        source_text = get_source(@source)
 
-        lines = source_text.split(/\r?\n/)
+        lines = source_text.split(/\n/)
 
         search_space = (lines.first(@lines) + lines.last(@lines)).join("\n")
 

--- a/lib/rouge/guessers/util.rb
+++ b/lib/rouge/guessers/util.rb
@@ -1,7 +1,7 @@
 module Rouge
   module Guessers
     module Util
-      module StringNormalizer
+      module SourceNormalizer
         UTF8_BOM = "\xEF\xBB\xBF"
         UTF8_BOM_RE = /\A#{UTF8_BOM}/
 
@@ -20,9 +20,9 @@ module Rouge
       def get_source(source)
         case source
         when String
-          StringNormalizer.normalize(source)
+          SourceNormalizer.normalize(source)
         when ->(s){ s.respond_to? :read }
-          StringNormalizer.normalize(source.read)
+          SourceNormalizer.normalize(source.read)
         else
           raise 'invalid source'
         end

--- a/lib/rouge/guessers/util.rb
+++ b/lib/rouge/guessers/util.rb
@@ -8,7 +8,6 @@ module Rouge
         # @param [String,nil] source
         # @return [String,nil]
         def self.normalize(source)
-          return nil unless source
           source.sub(UTF8_BOM_RE, '').gsub(/\r\n/, "\n")
         end
       end

--- a/lib/rouge/guessers/util.rb
+++ b/lib/rouge/guessers/util.rb
@@ -1,6 +1,18 @@
 module Rouge
   module Guessers
     module Util
+      module StringNormalizer
+        UTF8_BOM = "\xEF\xBB\xBF"
+        UTF8_BOM_RE = /\A#{UTF8_BOM}/
+
+        # @param [String,nil] source
+        # @return [String,nil]
+        def self.normalize(source)
+          return nil unless source
+          source.sub(UTF8_BOM_RE, '').gsub(/\r\n/, "\n")
+        end
+      end
+
       def test_glob(pattern, path)
         File.fnmatch?(pattern, path, File::FNM_DOTMATCH | File::FNM_CASEFOLD)
       end
@@ -8,9 +20,9 @@ module Rouge
       def get_source(source)
         case source
         when String
-          source
+          StringNormalizer.normalize(source)
         when ->(s){ s.respond_to? :read }
-          source.read
+          StringNormalizer.normalize(source.read)
         else
           raise 'invalid source'
         end

--- a/lib/rouge/guessers/util.rb
+++ b/lib/rouge/guessers/util.rb
@@ -17,14 +17,15 @@ module Rouge
         File.fnmatch?(pattern, path, File::FNM_DOTMATCH | File::FNM_CASEFOLD)
       end
 
+      # @param [String,IO] source
+      # @return [String]
       def get_source(source)
-        case source
-        when String
-          SourceNormalizer.normalize(source)
-        when ->(s){ s.respond_to? :read }
+        if source.respond_to?(:to_str)
+          SourceNormalizer.normalize(source.to_str)
+        elsif source.respond_to?(:read)
           SourceNormalizer.normalize(source.read)
         else
-          raise 'invalid source'
+          raise ArgumentError, "Invalid source: #{source.inspect}"
         end
       end
     end

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -42,6 +42,7 @@ module Rouge
       # markdown lexer for highlighting internal code blocks.
       #
       def find_fancy(str, code=nil, additional_options={})
+
         if str && !str.include?('?') && str != 'guess'
           lexer_class = find(str)
           return lexer_class && lexer_class.new(additional_options)
@@ -109,7 +110,7 @@ module Rouge
       def demo(arg=:absent)
         return @demo = arg unless arg == :absent
 
-        @demo = File.read(demo_file, encoding: 'utf-8')
+        @demo = File.read(demo_file, mode: 'rt:bom|utf-8')
       end
 
       # @return a list of all lexers.

--- a/spec/lexers/xml_spec.rb
+++ b/spec/lexers/xml_spec.rb
@@ -2,6 +2,7 @@
 
 describe Rouge::Lexers::XML do
   let(:subject) { Rouge::Lexers::XML.new }
+  let(:bom) { "\xEF\xBB\xBF" }
 
   describe 'guessing' do
     include Support::Guessing
@@ -26,6 +27,7 @@ describe Rouge::Lexers::XML do
 
     it 'guesses by source' do
       assert_guess :source => '<?xml version="1.0" encoding="utf-8"?>'
+      assert_guess :source => %{#{bom}<?xml version="1.0" encoding="utf-8"?>}
       assert_guess :source => '<!DOCTYPE xml>'
       deny_guess   :source => '<!DOCTYPE html>'
     end


### PR DESCRIPTION
* remove UTF-8 BOM (to fix #767)
* replace CRLF to LF  (to fix #772)
* use `rt:bom|utf-8` for `File.read` mode