### PR TITLE
add Lexer.guess { fallback }

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -150,6 +150,8 @@ module Rouge
       #   The source itself, which, if guessing by mimetype or filename
       #   fails, will be searched for shebangs, <!DOCTYPE ...> tags, and
       #   other hints.
+      # @param [Proc] fallback called if multiple lexers are detected.
+      #   If omitted, Guesser::Ambiguous is raised.
       #
       # @see Lexer.detect?
       # @see Lexer.guesses

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -22,7 +22,9 @@ module Rouge
         new(opts).lex(stream, &b)
       end
 
-      # Given a string, return the correct lexer class.
+      # Given a name in string, return the correct lexer class.
+      # @param [String] name
+      # @return [Class<Rouge::Lexer>,nil]
       def find(name)
         registry[name.to_s]
       end
@@ -151,13 +153,18 @@ module Rouge
       #
       # @see Lexer.detect?
       # @see Lexer.guesses
-      def guess(info={})
+      # @return [Class<Rouge::Lexer>]
+      def guess(info={}, &fallback)
         lexers = guesses(info)
 
         return Lexers::PlainText if lexers.empty?
         return lexers[0] if lexers.size == 1
 
-        raise Guesser::Ambiguous.new(lexers)
+        if fallback
+          fallback.call(lexers)
+        else
+          raise Guesser::Ambiguous.new(lexers)
+        end
       end
 
       def guess_by_mimetype(mt)

--- a/spec/lexer_spec.rb
+++ b/spec/lexer_spec.rb
@@ -3,6 +3,14 @@
 describe Rouge::Lexer do
   include Support::Lexing
 
+  it 'raises errors in .guess by default' do
+    assert { (Rouge::Lexer.guess(filename: 'foo.pl') rescue nil) == nil }
+  end
+
+  it 'customizes ambiguous cases in .guess' do
+    assert { Rouge::Lexer.guess(filename: 'foo.pl') { :fallback } == :fallback }
+  end
+
   it 'makes a simple lexer' do
     a_lexer = Class.new(Rouge::RegexLexer) do
       state :root do


### PR DESCRIPTION
This PR adds a way to customize a fallback logic:

```ruby
lexer = Rouge::Lexer.guess(...) do |lexers|
   lexers[0] # or Rouge::Lexers::PlainText
end
```

`.guess` raises `Guesser::Ambiguous` by default but in the most of cases it is rescued, I think.

----

Here is my code that employs Rouge. `Lexer.guess` is not suitable there because it raises errors, but with this PR I can use `Lexer.guess`:

https://github.com/bitjourney/mato/blob/8dd8d808971fc786d872d46cc2ca6daeef6810ed/lib/mato/html_filters/syntax_highlight.rb#L27-L33 