### PR TITLE
fix char literals in Haskell

### DIFF
--- a/lib/rouge/lexers/haskell.rb
+++ b/lib/rouge/lexers/haskell.rb
@@ -148,7 +148,7 @@ module Rouge
       state :character do
         rule /\\/ do
           token Str::Escape
-          push :character_end
+          goto :character_end
           push :escape
         end
 
@@ -174,7 +174,7 @@ module Rouge
         rule /\^[\]\[A-Z@\^_]/, Str::Escape, :pop!
         rule /#{ascii.join('|')}/, Str::Escape, :pop!
         rule /o[0-7]+/i, Str::Escape, :pop!
-        rule /x[\da-f]/i, Str::Escape, :pop!
+        rule /x[\da-f]+/i, Str::Escape, :pop!
         rule /\d+/, Str::Escape, :pop!
         rule /\s+\\/, Str::Escape, :pop!
       end

--- a/spec/visual/samples/haskell
+++ b/spec/visual/samples/haskell
@@ -377,3 +377,9 @@ check i n x f (Result (Just False) args : rs) = do
 progressReport :: Bool -> Int -> Int -> IO ()
 progressReport _ _ _ = return ()
 
+foo :: String
+foo = replicate n '\x1f363'
+  where n = 32
+
+bar :: String
+bar = "\x1f389\x1f363\x1f389"


### PR DESCRIPTION
Fix #780: *Haskell hexadecimal escape characters are not correctly highlighted* by @Tosainu 

<img width="401" alt="screen shot 2017-09-18 at 12 02 57" src="https://user-images.githubusercontent.com/101800/30527979-5c25a364-9c69-11e7-8f6b-f0ca4e63ef4d.png">

Ref. https://www.haskell.org/onlinereport/lexemes.html