### PR TITLE
Kotlin: fix generic functions

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -43,23 +43,23 @@ module Rouge
         rule %r'"(\\\\|\\"|[^"\n])*["\n]'m, Str
         rule %r"'\\.'|'[^\\]'", Str::Char
         rule %r"[0-9](\.[0-9]+)?([eE][+-][0-9]+)?[flFL]?|0[xX][0-9a-fA-F]+[Ll]?", Num
-        rule %r'(companion)(\s+)(object)' do
+        rule %r'\b(companion)(\s+)(object)\b' do
           groups Keyword, Text, Keyword
         end
-        rule %r'(class|data\s+class|interface|object)(\s+)' do
+        rule %r'\b(class|data\s+class|interface|object)(\s+)' do
           groups Keyword::Declaration, Text
           push :class
         end
-        rule %r'(package|import)(\s+)' do
+        rule %r'\b(package|import)(\s+)' do
           groups Keyword, Text
           push :package
         end
-        rule %r'(val|var)(\s+)' do
+        rule %r'\b(val|var)(\s+)' do
           groups Keyword::Declaration, Text
           push :property
         end
-        rule %r/fun/, Keyword
-        rule /(?:#{keywords.join('|')})\b/, Keyword
+        rule %r/\bfun\b/, Keyword
+        rule /\b(?:#{keywords.join('|')})\b/, Keyword
         rule id, Name
       end
 

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -3,8 +3,10 @@
 module Rouge
   module Lexers
     class Kotlin < RegexLexer
+      # https://kotlinlang.org/docs/reference/grammar.html
+
       title "Kotlin"
-      desc "Kotlin <http://kotlinlang.org>"
+      desc "Kotlin Programming Language (http://kotlinlang.org)"
 
       tag 'kotlin'
       filenames '*.kt'
@@ -56,10 +58,7 @@ module Rouge
           groups Keyword::Declaration, Text
           push :property
         end
-        rule %r'(fun)(\s+)' do
-          groups Keyword, Text
-          push :function
-        end
+        rule %r/fun/, Keyword
         rule /(?:#{keywords.join('|')})\b/, Keyword
         rule id, Name
       end
@@ -74,10 +73,6 @@ module Rouge
 
       state :property do
         rule id, Name::Property, :pop!
-      end
-
-      state :function do
-        rule id, Name::Function, :pop!
       end
     end
   end

--- a/spec/visual/samples/kotlin
+++ b/spec/visual/samples/kotlin
@@ -128,3 +128,13 @@ fun makeField(s: String): Field {
     return Field(longestLine.length, lines.size) { i, j -> lines[i][j] == '*' }
 }
 
+fun <T, V> genericFunction() {
+    return
+}
+
+fun String.extensionFunction() {
+   return
+}
+
+fun <T, V> String.genericExtensionFunction() {
+   return


### PR DESCRIPTION
Fix #736.

There ware two ways to handle nested syntax in Rouge:

1. Use state. https://github.com/jneen/rouge/blob/master/lib/rouge/lexers/ruby.rb is a good example
2. Use regexp to handle only keywords and punctuations

*1)* is better but difficult. In this PR, just use regexp for `fun`.

related: #770

<img width="418" alt="screen shot 2017-09-19 at 10 41 38" src="https://user-images.githubusercontent.com/101800/30572190-2ab08e02-9d27-11e7-9666-9b44bac0ce19.png">
