### PR TITLE
Add source code and changelog links to gemspec

### DIFF
--- a/rouge.gemspec
+++ b/rouge.gemspec
@@ -16,4 +16,8 @@ Gem::Specification.new do |s|
   s.executables = %w(rougify)
   s.licenses = ['MIT', 'BSD-2-Clause']
   s.required_ruby_version = '>= 2.0'
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/jneen/rouge',
+    'changelog_uri' => 'https://github.com/jneen/rouge/blob/master/CHANGELOG.md'
+  }
 end


### PR DESCRIPTION
This makes it easier for tools to programatically find the source code and changelog for the gem - for example, [Dependabot](https://dependabot.com/) uses this when bumping your dependencies automatically to provide a link to the changleog and any GitHub releases.

This is in as-yet-undeployed docs for RubyGems, merged in a couple of weeks ago from https://github.com/rubygems/rubygems/pull/1960.