### PR TITLE
Allow double backtick F# identifiers

### DIFF
--- a/lib/rouge/lexers/fsharp.rb
+++ b/lib/rouge/lexers/fsharp.rb
@@ -41,7 +41,7 @@ module Rouge
       end
 
       operator = %r([\[\];,{}_()!$%&*+./:<=>?@^|~#-]+)
-      id = /[a-z][\w']*/i
+      id = /([a-z][\w']*)|(``[^`\n\r\t]+``)/i
       upper_id = /[A-Z][\w']*/
 
       state :root do

--- a/spec/visual/samples/fsharp
+++ b/spec/visual/samples/fsharp
@@ -177,7 +177,8 @@ try
     with
     | exn -> 
         if exn.InnerException <> null then
-            sprintf "Build failed.\nError:\n%s\nInnerException:\n%s" exn.Message exn.InnerException.Message
+            let ``inner message.#1`` = exn.InnerException.Message
+            sprintf "Build failed.\nError:\n%s\nInnerException:\n%s" exn.Message ``inner message.#1``
             |> traceError
             printUsage()
         else


### PR DESCRIPTION
The [F# Spec (Section 3.4)](http://fsharp.org/specs/language-spec/4.0/FSharpSpec-4.0-latest.pdf) allows identifiers (eg. methods, variables) to contain essentially any printable character in double backticks.

```fsharp
let ``(my fn)`` x = x + 1
let ``my var #1`` = "a"
```

Screenshot of the change:

![image](https://user-images.githubusercontent.com/2106129/31185768-6acebc62-a8f2-11e7-9b9c-f83ec9345937.png)

Previously the lexer assigned an error