### PR TITLE
Swift support for backticks and keypath syntax

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -66,7 +66,7 @@ module Rouge
         mixin :whitespace
         rule /\$(([1-9]\d*)?\d)/, Name::Variable
 
-        rule %r{[()\[\]{}:;,?]}, Punctuation
+        rule %r{[()\[\]{}:;,?\\]}, Punctuation
         rule %r([-/=+*%<>!&|^.~]+), Operator
         rule /@?"/, Str, :dq
         rule /'(\\.|.)'/, Str::Char
@@ -134,6 +134,10 @@ module Rouge
           else
             token Name
           end
+        end
+
+        rule /(`)(#{id})(`)/ do
+          groups Punctuation,Name,Punctuation
         end
       end
 

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -389,4 +389,10 @@ precedencegroup ComparisonPrecedence {
 }
 infix operator <> : ComparisonPrecedence
 
+// keyword as identifier
+var `var` = 3
+
+// keypath
+let keypath = \Person.firstName
+
 foo() // end-of-file comment


### PR DESCRIPTION
Some small improvements to the Swift lexer:

* Any word in backticks is an identifier even if it's a reserved word.  [Ref](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/doc/uid/TP40014097-CH30-ID412); since at least Swift 2.
* Backslash is a punctuation character.  [Ref](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Expressions.html#//apple_ref/doc/uid/TP40014097-CH32-ID563); new in Swift 4.

![screen shot 2017-10-05 at 13 51 59](https://user-images.githubusercontent.com/26768470/31228174-64e2c57c-a9d4-11e7-84c2-146af2e9ef63.png)