### PR TITLE
Fix #796: comments not followed by a newline are not highlighted

### DIFF
--- a/lib/rouge/lexers/c.rb
+++ b/lib/rouge/lexers/c.rb
@@ -85,7 +85,7 @@ module Rouge
 
       state :whitespace do
         rule /\n+/m, Text, :bol
-        rule %r(//(\\.|.)*?\n), Comment::Single, :bol
+        rule %r(//(\\.|.)*?$), Comment::Single, :bol
         mixin :inline_whitespace
       end
 

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -31,7 +31,7 @@ module Rouge
         rule %r'^\s*\[.*?\]', Name::Attribute
         rule %r'[^\S\n]+', Text
         rule %r'\\\n', Text # line continuation
-        rule %r'//.*?\n', Comment::Single
+        rule %r'//.*?$', Comment::Single
         rule %r'/[*].*?[*]/'m, Comment::Multiline
         rule %r'\n', Text
         rule %r'::|!!|\?[:.]', Operator

--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -99,8 +99,8 @@ module Rouge
         # heredocs
         rule /<<<('?)(#{id})\1\n.*?\n\2;?\n/im, Str::Heredoc
         rule /\s+/, Text
-        rule /#.*?\n/, Comment::Single
-        rule %r(//.*?\n), Comment::Single
+        rule /#.*?$/, Comment::Single
+        rule %r(//.*?$), Comment::Single
         # empty comment, otherwise seen as the start of a docstring
         rule %r(/\*\*/), Comment::Multiline
         rule %r(/\*\*.*?\*/)m, Str::Doc

--- a/lib/rouge/lexers/sass.rb
+++ b/lib/rouge/lexers/sass.rb
@@ -23,7 +23,7 @@ module Rouge
 
       state :content do
         # block comments
-        rule %r(//.*?\n) do
+        rule %r(//.*?$) do
           token Comment::Single
           pop!; starts_block :single_comment
         end
@@ -48,7 +48,7 @@ module Rouge
       end
 
       state :single_comment do
-        rule /.*?\n/, Comment::Single, :pop!
+        rule /.*?$/, Comment::Single, :pop!
       end
 
       state :multi_comment do

--- a/lib/rouge/lexers/scss.rb
+++ b/lib/rouge/lexers/scss.rb
@@ -13,7 +13,7 @@ module Rouge
 
       state :root do
         rule /\s+/, Text
-        rule %r(//.*?\n), Comment::Single
+        rule %r(//.*?$), Comment::Single
         rule %r(/[*].*?[*]/)m, Comment::Multiline
         rule /@import\b/, Keyword, :value
 

--- a/spec/lexers/c_spec.rb
+++ b/spec/lexers/c_spec.rb
@@ -16,4 +16,12 @@ describe Rouge::Lexers::C do
       assert_guess :mimetype => 'text/x-csrc'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'recognizes one-line comments not followed by a newline (#796)' do
+      assert_tokens_equal '// comment', ['Comment.Single', '// comment']
+    end
+  end
 end

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -14,4 +14,12 @@ describe Rouge::Lexers::Kotlin do
       assert_guess :mimetype => 'text/x-kotlin'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'recognizes one-line comments not followed by a newline (#797)' do
+      assert_tokens_equal '// comment', ['Comment.Single', '// comment']
+    end
+  end
 end

--- a/spec/lexers/php_spec.rb
+++ b/spec/lexers/php_spec.rb
@@ -24,4 +24,16 @@ describe Rouge::Lexers::PHP do
       deny_guess :filename => '.php', :source => '<?hh foo();'
     end
   end
+
+  describe 'lexing' do
+    include Support::Lexing
+
+    it 'recognizes hash comments not followed by a newline (#797)' do
+      assert_tokens_equal '# comment', ['Comment.Single', '# comment']
+    end
+
+    it 'recognizes double-slash comments not followed by a newline (#797)' do
+      assert_tokens_equal '// comment', ['Comment.Single', '// comment']
+    end
+  end
 end

--- a/spec/visual/samples/c
+++ b/spec/visual/samples/c
@@ -2649,3 +2649,4 @@ fast_yield:
 	return retval;
 }
 
+// Comment at EOF (#796)

--- a/spec/visual/samples/kotlin
+++ b/spec/visual/samples/kotlin
@@ -138,3 +138,6 @@ fun String.extensionFunction() {
 
 fun <T, V> String.genericExtensionFunction() {
    return
+}
+
+// comment at EOF (#797)

--- a/spec/visual/samples/sass
+++ b/spec/visual/samples/sass
@@ -389,3 +389,5 @@ button.short
 
 table
   :border-collapse collapse
+
+// Comment at EOF (#797)

--- a/spec/visual/samples/scss
+++ b/spec/visual/samples/scss
@@ -279,3 +279,5 @@ body {
     } 
   }
 }
+
+// Comment at EOF (#797)


### PR DESCRIPTION
A C/C++ one-line comment at the end of a file that is not followed by a newline will not be recognized, as reported in #796. 

From the looks of it, the Kotlin, PHP, and Sass/SCSS lexers are also affected. I can include fixes for those lexers in this pull request, or create a new PR just for them if preferred.