### PR TITLE
Add JEA file extensions to powershell

### DIFF
--- a/lib/rouge/lexers/powershell.rb
+++ b/lib/rouge/lexers/powershell.rb
@@ -9,7 +9,7 @@ module Rouge
       desc 'powershell'
       tag 'powershell'
       aliases 'posh'
-      filenames '*.ps1', '*.psm1', '*.psd1'
+      filenames '*.ps1', '*.psm1', '*.psd1', '*.psrc', '*.pssc'
       mimetypes 'text/x-powershell'
 
       ATTRIBUTES = %w(

--- a/spec/lexers/powershell_spec.rb
+++ b/spec/lexers/powershell_spec.rb
@@ -11,6 +11,9 @@ describe Rouge::Lexers::Powershell do
     it 'guesses by filename' do
       assert_guess :filename => 'foo.ps1'
       assert_guess :filename => 'foo.psm1'
+      assert_guess :filename => 'foo.psd1'
+      assert_guess :filename => 'foo.psrc'
+      assert_guess :filename => 'foo.pssc'
     end
 
   end


### PR DESCRIPTION
These commits add functionality to the PowerShell lexer for handling [JEA](https://docs.microsoft.com/en-us/powershell/jea/overview#get-started-with-jea) configuration files, both for [role capabilities](https://docs.microsoft.com/en-us/powershell/jea/role-capabilities) and for [session configurations](https://docs.microsoft.com/en-us/powershell/jea/session-configurations).

It also updates the tests to account for all supported PowerShell file types.

This resolves #808.