### PR TITLE
Support Drupal 8 file name extension in the php lexer

### DIFF
--- a/lib/rouge/lexers/php.rb
+++ b/lib/rouge/lexers/php.rb
@@ -10,7 +10,7 @@ module Rouge
       filenames '*.php', '*.php[345t]','*.phtml',
                 # Support Drupal file extensions, see:
                 # https://github.com/gitlabhq/gitlabhq/issues/8900
-                '*.module', '*.inc', '*.profile', '*.install', '*.test'
+                '*.module', '*.inc', '*.profile', '*.install', '*.test', '*.theme'
       mimetypes 'text/x-php'
 
       option :start_inline, 'Whether to start with inline php or require <?php ... ?>. (default: best guess)'


### PR DESCRIPTION
Drupal 8 now uses *.theme extension for PHP files.

https://www.drupal.org/docs/8/theming-drupal-8/modifying-attributes-in-a-theme-file