### PR TITLE
Don't treat `error` specially in Haskell

### DIFF
--- a/lib/rouge/lexers/haskell.rb
+++ b/lib/rouge/lexers/haskell.rb
@@ -55,7 +55,6 @@ module Rouge
 
         rule /\bimport\b/, Keyword::Reserved, :import
         rule /\bmodule\b/, Keyword::Reserved, :module
-        rule /\berror\b/, Name::Exception
         rule /\b(?:#{reserved.join('|')})\b/, Keyword::Reserved
         # not sure why, but ^ doesn't work here
         # rule /^[_a-z][\w']*/, Name::Function


### PR DESCRIPTION
`error` was highlighted with `Name::Exception` which caused failures when parsing
things like `error'` which is a perfectly valid name. `error` is a regular
function with some admittedly odd behavior, it isn't itself an exception, and
there are lots of functions which may throw exceptions, so I don't think it
makes sense to highlight it specially.

Example failure with `error'`: http://rouge.jneen.net/pastes/3mwp