### PR TITLE
[Swift] Tuple destructuring, function call with lambda argument

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -112,8 +112,8 @@ module Rouge
           push :tuple
         end
 
-        rule /(?!\b(if|while|for|private|internal|unowned|switch|case)\b)\b#{id}(?=(\?|!)?\s*[(])/ do |m|
-          if m[0] =~ /^[[:upper:]]/
+        rule /(?!\b(if|while|for|private|internal|unowned|switch|case)\b)\b#{id}(?=(\?|!)?\s*[({])/ do |m|
+          if m[1] == '(' && m[0] =~ /^[[:upper:]]/
             token Keyword::Type
           else
             token Name::Function

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -107,6 +107,11 @@ module Rouge
           groups Keyword, Text, Name::Variable
         end
 
+        rule /(let|var)\b(\s*)([(])/ do
+          groups Keyword, Text, Punctuation
+          push :tuple
+        end
+
         rule /(?!\b(if|while|for|private|internal|unowned|switch|case)\b)\b#{id}(?=(\?|!)?\s*[(])/ do |m|
           if m[0] =~ /^[[:upper:]]/
             token Keyword::Type
@@ -137,8 +142,16 @@ module Rouge
         end
 
         rule /(`)(#{id})(`)/ do
-          groups Punctuation,Name,Punctuation
+          groups Punctuation, Name, Punctuation
         end
+      end
+
+      state :tuple do
+        rule /(#{id})/, Name::Variable
+        rule /,/, Punctuation
+        rule /[(]/, Punctuation, :push
+        rule /[)]/, Punctuation, :pop!
+        mixin :inline_whitespace
       end
 
       state :dq do

--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -142,12 +142,15 @@ module Rouge
         end
 
         rule /(`)(#{id})(`)/ do
-          groups Punctuation, Name, Punctuation
+          groups Punctuation, Name::Variable, Punctuation
         end
       end
 
       state :tuple do
         rule /(#{id})/, Name::Variable
+        rule /(`)(#{id})(`)/ do
+            groups Punctuation, Name::Variable, Punctuation
+        end
         rule /,/, Punctuation
         rule /[(]/, Punctuation, :push
         rule /[)]/, Punctuation, :pop!

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -401,4 +401,13 @@ var ((`func`, foo), `protocol`) = ((3, 4), 5)
 var ( t3 , /* comment */
     ( t4 , t5 ) ) = ("a", ("b", "c"))
 
+// function with lambda argument
+func funcWithLambdaArg(_ fn: (Int) -> Int) -> Int {
+    return fn(1)
+}
+
+funcWithLambdaArg { x in x + 5 }
+funcWithLambdaArg { $0 + 5 }
+funcWithLambdaArg({ x in x + 5 })
+
 foo() // end-of-file comment

--- a/spec/visual/samples/swift
+++ b/spec/visual/samples/swift
@@ -395,4 +395,10 @@ var `var` = 3
 // keypath
 let keypath = \Person.firstName
 
+// tuple destructuring
+let (t1, t2) = (1, 2)
+var ((`func`, foo), `protocol`) = ((3, 4), 5)
+var ( t3 , /* comment */
+    ( t4 , t5 ) ) = ("a", ("b", "c"))
+
 foo() // end-of-file comment


### PR DESCRIPTION
I added Swift support for tuple destructuring: addresses issue #833.
I also fixed function calls with lambdas as the first argument.

Before:
<img width="287" alt="2017-12-11 at 10 59 24 pm" src="https://user-images.githubusercontent.com/5590046/33866865-fd451ee2-dec6-11e7-9aed-cda7716f1d3c.png">
When tuple destructuring occurs, `let`/`var` are incorrectly parsed as function names instead of keywords.

After:
<img width="292" alt="2017-12-11 at 11 00 00 pm" src="https://user-images.githubusercontent.com/5590046/33866879-0d3f0e20-dec7-11e7-93a1-065dafcbb13f.png">
Tuple destructuring is parsed as expected.