### PR TITLE
[do not merge] Add HTML::Mason lexer

### DIFF
--- a/lib/rouge/demos/mason
+++ b/lib/rouge/demos/mason
@@ -1,0 +1,21 @@
+<%doc>
+    This is a mason component.
+</%doc>
+
+<%args>
+    $color         # this argument is required!
+    $size => 20    # default size
+    $country => undef   # this argument is optional, defalt value is 'undef'
+    @items => (1, 2, 'something else')
+    %pairs => (name => "John", age => 29)
+</%args>
+
+# A random block of Perl code
+<%perl>
+    my @people = ('mary' 'john' 'pete' 'david');
+<%perl>
+
+# Note how each line of code begins with the mandatory %
+% foreach my $person (@people) {
+    Name: <% $person %>
+% }

--- a/lib/rouge/lexers/mason.rb
+++ b/lib/rouge/lexers/mason.rb
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+    module Lexers
+      class Mason < RegexLexer
+        title "Mason"
+        desc %q(<desc for="this-lexer">Mason</desc>)
+        tag 'mason'
+        filenames '*.mi', '*.m'
+        mimetypes 'text/x-mason', 'application/x-mason'
+
+        def initialize(*)
+            super
+            @perl = Perl.new(options)
+            @html = HTML.new(options)
+          end
+  
+        def self.detect?(text)
+          return false if text.doctype?(/[html|xml]/)
+          return true if text.doctype?
+        end
+
+        blocks = %w(
+            cleanup doc args flags attr once shared init perl text filter
+        )
+
+        subcomponents = %w(
+            def method
+        )
+  
+        state :root do
+
+            # Comments
+            rule /^#.*?$/, Comment::Single
+
+            # doc block
+            rule /(<%doc>)([^<]*)(<\/%doc>)/ do |m|
+                token Keyword::Constant, m[1]
+                token Text, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # text block (not interpreted)
+            rule /(<%text>)([^<]*)(<\/%text>)/ do |m|
+                token Keyword::Constant, m[1]
+                token Text, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # args block
+            rule /(<%args>)([^<]*)(<\/%args>)/ do |m|
+                token Keyword::Constant, m[1]
+                delegate @perl, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # flags block
+            rule /(<%flags>)([^<]*)(<\/%flags>)/ do |m|
+                token Keyword::Constant, m[1]
+                delegate @perl, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # attr block
+            rule /(<%attr>)([^<]*)(<\/%attr>)/ do |m|
+                token Keyword::Constant, m[1]
+                delegate @perl, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # init block
+            rule /(<%init>)([^<]*)(<\/%init>)/ do |m|
+                token Keyword::Constant, m[1]
+                delegate @perl, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # once block
+            rule /(<%once>)([^<]*)(<\/%once>)/ do |m|
+                token Keyword::Constant, m[1]
+                delegate @perl, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # shared block
+            rule /(<%shared>)([^<]*)(<\/%shared>)/ do |m|
+                token Keyword::Constant, m[1]
+                delegate @perl, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # perl block
+            rule /(<%perl>)([^<]*)(<\/%perl>)/ do |m|
+                token Keyword::Constant, m[1]
+                delegate @perl, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # cleanup block
+            rule /(<%cleanup>)([^<]*)(<\/%cleanup>)/ do |m|
+                token Keyword::Constant, m[1]
+                delegate @perl, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # filter block
+            rule /(<%filter>)([^<]*)(<\/%filter>)/ do |m|
+                token Keyword::Constant, m[1]
+                delegate @perl, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # def block
+            rule /(<%def([^>]*)>)([^<]*)(<\/%def>)/ do |m|
+                token Keyword::Constant, m[1]
+                token Keyword::Type, m[2]
+                delegate @perl, m[3]
+                token Keyword::Constant, m[4]
+            end
+
+            # method block
+            rule /(<%method([^>]*)>)([^<]*)(<\/%method>)/ do |m|
+                token Keyword::Constant, m[1]
+                token Keyword::Type, m[2]
+                delegate @perl, m[3]
+                token Keyword::Constant, m[4]
+            end
+
+            # component call
+            rule /(<&)(.*)(&>)/ do |m|
+                token Keyword::Constant, m[1]
+                token Text, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            # component substitution
+            rule /(<%)(.*)(%>)/ do |m|
+                token Keyword::Constant, m[1]
+                delegate @perl, m[2]
+                token Keyword::Constant, m[3]
+            end
+
+            rule /^%.*/ do
+                delegate @perl
+            end
+
+            rule /.*/ do
+                delegate @html
+            end
+        end
+      end
+    end
+  end
+  

--- a/spec/lexers/mason_spec.rb
+++ b/spec/lexers/mason_spec.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Mason do
+  let(:subject) { Rouge::Lexers::Mason.new }
+  let(:bom) { "\xEF\xBB\xBF" }
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.mas'
+      assert_guess :filename => 'foo.mi'
+      assert_guess :filename => 'foo.mas'
+    end
+
+    it 'guesses by mimetype' do
+      assert_guess :mimetype => 'text/x-mason'
+      assert_guess :mimetype => 'application/x-mason'
+    end
+
+  end
+end

--- a/spec/visual/samples/mason
+++ b/spec/visual/samples/mason
@@ -1,0 +1,109 @@
+<%doc>
+    This is a mason component.
+</%doc>
+
+<%args>
+    $color         # this argument is required!
+    $size => 20    # default size
+    $country => undef   # this argument is optional, defalt value is 'undef'
+    @items => (1, 2, 'something else')
+    %pairs => (name => "John", age => 29)
+</%args>
+
+<%flags>
+    inherit => "page-framework.mi"
+</%flags>
+
+<%attr>
+author => 'maria ines parnisari'
+</%attr>
+
+<%once>
+    $Schema = Apprentice::Data->$schema;
+</%once>
+
+<%shared>
+    my $shared_var = 25;
+</%shared>
+
+<%init>
+    my $cookies = Apache::Cookie->fetch;
+</%init>
+
+# A random block of Perl code
+<%perl>
+    my @people = ('mary' 'john' 'pete' 'david');
+</%perl>
+
+# Note how each line of code begins with the mandatory %
+% foreach my $person (@people) {
+    Name: <% $person %>
+% }
+
+            % this is not perl code
+
+Here at wally world you will find all the finest accoutrements.
+
+What follows is a table.
+
+% my @array = qw(zero one two);
+
+<table>
+%       foreach my $row (0..$#array) {
+            <tr>
+                <td><% $row          %></td>
+                <td><% $array[$row]  %></td>
+            </tr>
+%        }
+</table>
+
+# These are all component calls
+<& path/to/component &>
+<& $component &>
+<& menu, width => 100, height => 200 &>
+
+# Special globals $m and $r
+%   my $result = $m->base_comp;
+%   my $apache = $r->name;
+
+# a nice PRIVATE subcomponent that renders a hyperlink
+<%def .make_a_link>
+    <a href="<% url %>"> <% text %></a>
+<%args>
+    $path
+    %query => ()
+    $text
+</%args>
+<%init>
+    my $url = $path;
+    if (scalar (keys %query) > 0) {
+        $url = $url . "?"
+    }
+    foreach my $queryParam (keys %query) {
+        $url = $url . $queryParam . "=" . $query{$queryParam} . "&";
+    }
+</%init>
+<%perl>
+    <a href="<% url %>"> <% text %></a>
+</%perl>
+</%def>
+
+<%method getPublic>
+%    my $text = "hello world";
+<b><% text %></b>
+</%method>
+
+<%text>
+# This is not interpreted and is printed as is
+%   my $variable = "hello";
+</%text>
+
+# This code runs at the very end of the component
+<%filter>
+    s/(\w+)/\U$1/g #uppercase the entire thing
+</%filter>
+
+<%cleanup>
+# This runs at the end.
+    $db->disconnect();
+</%cleanup>


### PR DESCRIPTION
Hi, I got most of this Mason lexer working, but I have a  couple of questions. (Basically the syntax is this: everything is considered to be HTML code unless a special block, a substitution tag, a component call, or a line that begins with `%` is encountered).

1. How do I remove all the duplication in the rules?
1. All the lines that start with `%` (no leading characters) must be considered perl code. I wrote the rule but somehow some lines that match produce errors. E.g lines 66 and 67 of the demo code.
1. How do I place the rules so that when HTML code is encountered, the "component substitution" rule can apply there too?
1. Is it possible to recursively call the lexer? E.g. for this code:

   ```
   <%method myFunction>
   ...
   </%method>
    ```

     Everything in the ... can be formatted according to this lexer's rule.