### PR TITLE
Don't treat `[` as a part of an attribute name

### DIFF
--- a/lib/rouge/lexers/sass.rb
+++ b/lib/rouge/lexers/sass.rb
@@ -42,7 +42,7 @@ module Rouge
 
         rule /:/, Name::Attribute, :old_style_attr
 
-        rule(/(?=.+?:([^a-z]|$))/) { push :attribute }
+        rule(/(?=[^\[\n]+?:([^a-z]|$))/) { push :attribute }
 
         rule(//) { push :selector }
       end

--- a/lib/rouge/lexers/scss.rb
+++ b/lib/rouge/lexers/scss.rb
@@ -20,7 +20,7 @@ module Rouge
         mixin :content_common
 
         rule(/(?=[^;{}][;}])/) { push :attribute }
-        rule(/(?=[^;{}:]+:[^a-z])/) { push :attribute }
+        rule(/(?=[^;{}:\[]+:[^a-z])/) { push :attribute }
 
         rule(//) { push :selector }
       end

--- a/spec/visual/samples/sass
+++ b/spec/visual/samples/sass
@@ -45,7 +45,6 @@ $yellow: #fc0
     :text-decoration underline
     +compound
 
-
 #main
   :width 15em
   :color #0000ff
@@ -56,6 +55,14 @@ $yellow: #fc0
       :width 2px
   .cool
     :width 100px
+
+  a
+    &[href^="mailto:"]
+      :white-space nowrap
+
+  div
+    a[href^="mailto:"]
+      :white-space nowrap
 
 #left
   +bordered

--- a/spec/visual/samples/scss
+++ b/spec/visual/samples/scss
@@ -52,6 +52,16 @@ body {
       height: 72px;
       display: block;
       text-decoration: none;
+
+      &[href^="mailto:"] {
+        white-space: nowrap;
+      }
+    }
+
+    div {
+      a[href^="mailto:"] {
+        white-space: nowrap;
+      }
     }
   }
 


### PR DESCRIPTION
Hello, I've been trying to fix #805.

Apparently, the lexers treat `&[href^="mailto:"]` as an attribute due to `:` symbol of `mailto:`. To fix that, I had them not treat `[` as a part of an attribute name.

The issue can be reploduced with the following example.
http://rouge.jneen.net/pastes/7G2N

```
a {
  &[href^="mailto:"] {
    white-space: nowrap;
  }
}
```

The part of the debug output of above example is:

```
lexer: scss
stack: [:root]
stream: "\n  &[href^=\"mailto:\""
  trying #<Rule /\s+/>
    got "\n  "
    yielding Text, "\n  "
lexer: scss
stack: [:root]
stream: "&[href^=\"mailto:\"] {"
  trying #<Rule /\s+/>
  trying #<Rule /\/\/.*?$/>
  trying #<Rule /\/[*].*?[*]\//m>
  trying #<Rule /@import\b/>
  entering mixin content_common
  trying #<Rule /@for\b/>
  trying #<Rule /@(debug|warn|if|each|while|else|return|media)/>
  trying #<Rule /(@mixin)(\s+)((?-mix:[\w-]+))/>
  trying #<Rule /(@function)(\s+)((?-mix:[\w-]+))/>
  trying #<Rule /@extend\b/>
  trying #<Rule /(@include)(\s+)((?-mix:[\w-]+))/>
  trying #<Rule /@(?-mix:[\w-]+)/>
  trying #<Rule /([$](?-mix:[\w-]+))([ \t]*)(:)/>
  exiting  mixin content_common
  trying #<Rule /(?=[^;{}][;}])/>
  trying #<Rule /(?=[^;{}:]+:[^a-z])/>
    got ""
    pushing :attribute
```

The patch of this Pull Request changes it as following:

```
$ diff -u debug-scss{,-after}.txt 
--- debug-scss.txt      2017-12-20 12:26:42.903885511 +0900
+++ debug-scss-after.txt        2017-12-20 12:39:44.493408945 +0900
@@ -22,7 +22,7 @@
   trying #<Rule /([$](?-mix:[\w-]+))([ \t]*)(:)/>
   exiting  mixin content_common
   trying #<Rule /(?=[^;{}][;}])/>
-  trying #<Rule /(?=[^;{}:]+:[^a-z])/>
+  trying #<Rule /(?=[^;{}:\[]+:[^a-z])/>
+  trying #<Rule //>
     got ""
-    pushing :attribute
-
+    pushing :selector

```