### PR TITLE
[Swift] Undo parsing function calls with trailing closure

### DIFF
--- a/lib/rouge/lexers/swift.rb
+++ b/lib/rouge/lexers/swift.rb
@@ -112,8 +112,8 @@ module Rouge
           push :tuple
         end
 
-        rule /(?!\b(if|while|for|private|internal|unowned|switch|case)\b)\b#{id}(?=(\?|!)?\s*[({])/ do |m|
-          if m[1] == '(' && m[0] =~ /^[[:upper:]]/
+        rule /(?!\b(if|while|for|private|internal|unowned|switch|case)\b)\b#{id}(?=(\?|!)?\s*[(])/ do |m|
+          if m[0] =~ /^[[:upper:]]/
             token Keyword::Type
           else
             token Name::Function


### PR DESCRIPTION
Patches some type name bugs, addressing #861.
Fixed examples:
<img width="416" alt="2018-01-11 at 6 53 33 am" src="https://user-images.githubusercontent.com/5590046/34824731-b18b944c-f69d-11e7-82de-d58149a3e6cf.png">
<img width="328" alt="2018-01-11 at 7 04 02 am" src="https://user-images.githubusercontent.com/5590046/34824733-b3f9b9c0-f69d-11e7-9428-b185dc7bd9d9.png">
<img width="217" alt="2018-01-11 at 7 04 19 am" src="https://user-images.githubusercontent.com/5590046/34824736-b5420dd2-f69d-11e7-8b79-359a02107069.png">

Edit: after careful consideration, I decided to revert parsing function calls with trailing closure.
It's not possible to perfectly identify such function calls using the current lexer and the feature causes more harm than good.