### PR TITLE
Detect *.mjs files as being JavaScript

### DIFF
--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -14,7 +14,7 @@ module Rouge
 
       tag 'javascript'
       aliases 'js'
-      filenames '*.js'
+      filenames '*.js', '*.mjs'
       mimetypes 'application/javascript', 'application/x-javascript',
                 'text/javascript', 'text/x-javascript'
 


### PR DESCRIPTION
The syntax highlighting lexer doesn't care about the input's parse goal so they both can be treated the same.

These are already usable in Node 9 with `--experimental-modules`.