### PR TITLE
Add missing "var" keyword in Java 10

### DIFF
--- a/lib/rouge/lexers/java.rb
+++ b/lib/rouge/lexers/java.rb
@@ -20,7 +20,7 @@ module Rouge
         public static strictfp super synchronized throws transient volatile
       )
 
-      types = %w(boolean byte char double float int long short void)
+      types = %w(boolean byte char double float int long short var void)
 
       id = /[a-zA-Z_][a-zA-Z0-9_]*/
 


### PR DESCRIPTION
Java 10 has introduced a new "var" keyword.

[JEP 286: Local-Variable Type Inference](http://openjdk.java.net/jeps/286)