### PR TITLE
Travis: gem install bundler before updating RubyGems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
   bundler: true
 bundler_args: --without development
 before_install:
+  - gem install bundler
   - gem update --system
-  - gem update bundler
 script:
   - bundle exec rake
   - bundle exec rubocop


### PR DESCRIPTION
This PR is a build-fix PR.

  - this is to avoid a `LoadError: cannot load such file -- bundler/dep_proxy`
  - see Travis build failure https://travis-ci.org/jneen/rouge/jobs/364038508 which shows this (only on Ruby 2.5)