### PR TITLE
ERB: Fix greedy comment matching

### DIFF
--- a/lib/rouge/lexers/erb.rb
+++ b/lib/rouge/lexers/erb.rb
@@ -37,7 +37,7 @@ module Rouge
 
       state :comment do
         rule close, Comment, :pop!
-        rule /.+(?=#{close})|.+/m, Comment
+        rule /.+?(?=#{close})|.+/m, Comment
       end
 
       state :ruby do

--- a/spec/visual/samples/erb
+++ b/spec/visual/samples/erb
@@ -13,6 +13,7 @@
 </table>
 <% end %>
 
+<%# Sometimes you just need to use a variable or two %>
 <% header_tag = 'h1' %>
 
 <<%= header_tag %>>


### PR DESCRIPTION
This little commit fixes the excessively greedy comment matching in ERB files, comments are after all constrained to the scope of the ERB tag in which they begin.