### PR TITLE
Images may not contain alt

### DIFF
--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -75,14 +75,8 @@ module Rouge
           push :url
         end
 
-        # links
-        rule /(\[)(#{edot}+?)(\])/ do
-          groups Punctuation, Name::Variable, Punctuation
-          push :link
-        end
-        
-        # images
-        rule /(!\[)(#{edot}*?)(\])/ do
+        # links and images
+        rule /(!?\[)(#{edot}*?)(\])/ do
           groups Punctuation, Name::Variable, Punctuation
           push :link
         end

--- a/lib/rouge/lexers/markdown.rb
+++ b/lib/rouge/lexers/markdown.rb
@@ -75,8 +75,14 @@ module Rouge
           push :url
         end
 
-        # links and images
-        rule /(!?\[)(#{edot}+?)(\])/ do
+        # links
+        rule /(\[)(#{edot}+?)(\])/ do
+          groups Punctuation, Name::Variable, Punctuation
+          push :link
+        end
+        
+        # images
+        rule /(!\[)(#{edot}*?)(\])/ do
           groups Punctuation, Name::Variable, Punctuation
           push :link
         end


### PR DESCRIPTION
`![](url)` is a vaild image insertion.

In fact, we also use links with empty text, but I'm not sure they are part of the markdown standard, so did not include them.

But if you don't mind, a simple change of `+` to `*` will make our life easier.