### PR TITLE
Add Kotlin lexer filetype recognition for Kotlin script files that en…

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -9,7 +9,7 @@ module Rouge
       desc "Kotlin Programming Language (http://kotlinlang.org)"
 
       tag 'kotlin'
-      filenames '*.kt'
+      filenames '*.kt', '*.kts'
       mimetypes 'text/x-kotlin'
 
       keywords = %w(

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -8,6 +8,7 @@ describe Rouge::Lexers::Kotlin do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.kt'
+      assert_guess :filename => 'foo.kts'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
…d in `kts`

`.kts` is the standard file extension for Kotlin script files.