### PR TITLE
Fix 'class_format' -> 'class' in HTMLLinewise opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Builtin formatters include:
 * `Rouge::Formatters::HTMLInline.new(theme)` - will render your code with no class names, but
   instead inline the styling options into the `style=` attribute. This is good for emails and
   other systems where CSS support is minimal.
-* `Rouge::Formatters::HTMLLinewise.new(formatter, class_format: 'line-%i')`
+* `Rouge::Formatters::HTMLLinewise.new(formatter, class: 'line-%i')`
   This formatter will split your code into lines, each contained in its own div. The
-  `class_format` option will be used to add a class name to the div, given the line
+  `class` option will be used to add a class name to the div, given the line
   number.
 * `Rouge::Formatters::HTMLPygments.new(formatter, css_class='codehilite')`
   wraps the given formatter with div wrappers generally expected by stylesheets designed for


### PR DESCRIPTION
👋 

Looks like a documentation error, `class` is the actual option key. [ref](https://github.com/jneen/rouge/blob/a58789a15bd21c16f026cf88045281b740622994/lib/rouge/formatters/html_linewise.rb#L8)

P.S. Thanks for the awesome work on Rogue! Learnt a lot by reading through the source :)