### PR TITLE
Minor fixes for HTML, CSS and JavaScript

### DIFF
--- a/lib/rouge/lexers/css.rb
+++ b/lib/rouge/lexers/css.rb
@@ -264,7 +264,7 @@ module Rouge
       state :stanza_value do
         rule /;/, Punctuation, :pop!
         rule(/(?=})/) { pop! }
-        rule /!important\b/, Comment::Preproc
+        rule /!\s*important\b/, Comment::Preproc
         rule /^@.*?$/, Comment::Preproc
         mixin :value
       end

--- a/lib/rouge/lexers/html.rb
+++ b/lib/rouge/lexers/html.rb
@@ -81,7 +81,7 @@ module Rouge
 
       state :tag do
         rule /\s+/m, Text
-        rule /[a-zA-Z0-9_:-]+\s*=/m, Name::Attribute, :attr
+        rule /[a-zA-Z0-9_:-]+\s*=\s*/m, Name::Attribute, :attr
         rule /[a-zA-Z0-9_:-]+/, Name::Attribute
         rule %r(/?\s*>)m, Name::Tag, :pop!
       end

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -206,6 +206,7 @@ module Rouge
 
       state :dq do
         rule /[^\\"]+/, Str::Double
+        rule /\\n/, Str::Double
         rule /\\"/, Str::Escape
         rule /"/, Str::Double, :pop!
       end

--- a/lib/rouge/lexers/javascript.rb
+++ b/lib/rouge/lexers/javascript.rb
@@ -206,7 +206,7 @@ module Rouge
 
       state :dq do
         rule /[^\\"]+/, Str::Double
-        rule /\\n/, Str::Double
+        rule /\\n/, Str::Escape
         rule /\\"/, Str::Escape
         rule /"/, Str::Double, :pop!
       end

--- a/spec/visual/samples/css
+++ b/spec/visual/samples/css
@@ -66,6 +66,7 @@ ul#nav li.new {
 #foo {
   unrecognized-prop: 1;
   -moz-prefixed-prop: 2;
+  font-size: 29px ! important;
 }
 
 a[target="_blank"] { 

--- a/spec/visual/samples/html
+++ b/spec/visual/samples/html
@@ -58,7 +58,7 @@ pre.syntax { padding: 5px; margin-top: 0px; }
 </style>
 </head>
 <body>
-<pre id="code-block" class="syntax"><span class="cm"># -*- coding: utf-8 -*-</span>
+<pre id = "code-block" class="syntax"><span class="cm"># -*- coding: utf-8 -*-</span>
 <span class="st st-db">&quot;&quot;&quot;</span><span class="st">
     pocoo.pkg.core.acl
     ~~~~~~~~~~~~~~~~~~

--- a/spec/visual/samples/javascript
+++ b/spec/visual/samples/javascript
@@ -5,6 +5,8 @@ var myOctal = 0x123;
 var myRegex = /asdf/;
 var myComplicatedRegex = /.[.](?=x\h\[[)])[^.{}abc]{foo}{3,}x{2,3}/
 var myObject = { a: 1, b: 2 }
+var someText = "hi";
+someText += "\nthere";
 
 var test = 123
 


### PR DESCRIPTION
Fix CSS: space is allowed between `!` and `important`
Fix HTML: space is allowed before and after equal signs for attributes
Fix JS: allows `\n` as a string