### PR TITLE
Implement the Terraform Lexer

### DIFF
--- a/lib/rouge/demos/hcl
+++ b/lib/rouge/demos/hcl
@@ -1,0 +1,7 @@
+service {
+    key = "value"
+}
+
+variable "ami" {
+    description = "the AMI to use"
+}

--- a/lib/rouge/demos/terraform
+++ b/lib/rouge/demos/terraform
@@ -1,0 +1,31 @@
+# From: https://github.com/terraform-providers/terraform-provider-aws/blob/master/examples/count/main.tf
+
+# Specify the provider and access details
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+resource "aws_elb" "web" {
+  name = "terraform-example-elb"
+
+  # The same availability zone as our instances
+  availability_zones = ["${aws_instance.web.*.availability_zone}"]
+
+  listener {
+    instance_port     = 80
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+
+  # The instances are registered automatically
+  instances = ["${aws_instance.web.*.id}"]
+}
+
+resource "aws_instance" "web" {
+  instance_type = "m1.small"
+  ami           = "${lookup(var.aws_amis, var.aws_region)}"
+
+  # This will create 4 instances
+  count = 4
+}

--- a/lib/rouge/lexers/hcl.rb
+++ b/lib/rouge/lexers/hcl.rb
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    class Hcl < RegexLexer
+      tag 'hcl'
+
+      title 'Hashicorp Configuration Language'
+      desc 'Hashicorp Configuration Language, used by Terraform and other Hashicorp tools'
+
+      state :multiline_comment do
+        rule %r([*]/), Comment::Multiline, :pop!
+        rule %r([^*/]+), Comment::Multiline
+        rule %r([*/]), Comment::Multiline
+      end
+
+      state :comments_and_whitespace do
+        rule /\s+/, Text
+        rule %r(//.*?$), Comment::Single
+        rule %r(#.*?$), Comment::Single
+        rule %r(/[*]), Comment::Multiline, :multiline_comment
+      end
+
+      state :primitives do
+        rule /[0-9][0-9]*\.[0-9]+([eE][0-9]+)?[fd]?([kKmMgG]b?)?/, Num::Float
+        rule /[0-9]+([kKmMgG]b?)?/, Num::Integer
+
+        rule /"/, Str::Double, :dq
+        rule /'/, Str::Single, :sq
+        rule /(<<-?)(\s*)(\'?)(\\?)(\w+)(\3)/ do |m|
+          groups Operator, Text, Str::Heredoc, Str::Heredoc, Name::Constant, Str::Heredoc
+          @heredocstr = Regexp.escape(m[5])
+          push :heredoc
+        end
+      end
+
+      def self.keywords
+        @keywords ||= Set.new %w()
+      end
+
+      def self.declarations
+        @declarations ||= Set.new %w()
+      end
+
+      def self.reserved
+        @reserved ||= Set.new %w()
+      end
+
+      def self.constants
+        @constants ||= Set.new %w(true false null)
+      end
+
+      def self.builtins
+        @builtins ||= %w()
+      end
+
+      id = /[$a-z_][a-z0-9_]*/io
+
+      state :root do
+        mixin :comments_and_whitespace
+        mixin :primitives
+
+        rule /\{/ do
+          token Punctuation
+          push :hash
+        end
+        rule /\[/ do
+          token Punctuation
+          push :array
+        end
+
+        rule id do |m|
+          if self.class.keywords.include? m[0]
+            token Keyword
+            push :composite
+          elsif self.class.declarations.include? m[0]
+            token Keyword::Declaration
+            push :composite
+          elsif self.class.reserved.include? m[0]
+            token Keyword::Reserved
+          elsif self.class.constants.include? m[0]
+            token Keyword::Constant
+          elsif self.class.builtins.include? m[0]
+            token Name::Builtin
+          else
+            token Name::Other
+            push :composite
+          end
+        end
+      end
+
+      state :composite do
+        mixin :comments_and_whitespace
+
+        rule /[{]/ do
+          token Punctuation
+          pop!
+          push :hash
+        end
+
+        rule /[\[]/ do
+          token Punctuation
+          pop!
+          push :array
+        end
+
+        mixin :root
+
+        rule //, Text, :pop!
+      end
+
+      state :hash do
+        mixin :comments_and_whitespace
+
+        rule /\=/, Punctuation
+        rule /\}/, Punctuation, :pop!
+
+        mixin :root
+      end
+
+      state :array do
+        mixin :comments_and_whitespace
+
+        rule /,/, Punctuation
+        rule /\]/, Punctuation, :pop!
+
+        mixin :root
+      end
+
+      state :dq do
+        rule /[^\\"]+/, Str::Double
+        rule /\\"/, Str::Escape
+        rule /"/, Str::Double, :pop!
+      end
+
+      state :sq do
+        rule /[^\\']+/, Str::Single
+        rule /\\'/, Str::Escape
+        rule /'/, Str::Single, :pop!
+      end
+
+      state :heredoc do
+        rule /\n/, Str::Heredoc, :heredoc_nl
+        rule /[^$\n]+/, Str::Heredoc
+        rule /[$]/, Str::Heredoc
+      end
+
+      state :heredoc_nl do
+        rule /\s*(\w+)\s*\n/ do |m|
+          if m[1] == @heredocstr
+            token Name::Constant
+            pop! 2
+          else
+            token Str::Heredoc
+          end
+        end
+
+        rule(//) { pop! }
+      end
+    end
+  end
+end

--- a/lib/rouge/lexers/terraform.rb
+++ b/lib/rouge/lexers/terraform.rb
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*- #
+
+module Rouge
+  module Lexers
+    load_lexer 'hcl.rb'
+
+    class Terraform < Hcl
+      title "Terraform"
+      desc "Terraform HCL Interpolations"
+
+      tag 'terraform'
+      aliases 'tf'
+      filenames '*.tf'
+
+      def self.keywords
+        @keywords ||= Set.new %w(
+          terraform module provider variable resource data provisioner output
+        )
+      end
+
+      def self.declarations
+        @declarations ||= Set.new %w(
+          var local
+        )
+      end
+
+      def self.reserved
+        @reserved ||= Set.new %w()
+      end
+
+      def self.constants
+        @constants ||= Set.new %w(true false null)
+      end
+
+      def self.builtins
+        @builtins ||= %w()
+      end
+
+      state :strings do
+        rule /\\./, Str::Escape
+        rule /\$\{/ do
+          token Keyword
+          push :interpolation
+        end
+      end
+
+      state :dq do
+        rule /[^\\"\$]+/, Str::Double
+        mixin :strings
+        rule /"/, Str::Double, :pop!
+      end
+
+      state :sq do
+        rule /[^\\'\$]+/, Str::Single
+        mixin :strings
+        rule /'/, Str::Single, :pop!
+      end
+
+      state :heredoc do
+        rule /\n/, Str::Heredoc, :heredoc_nl
+        rule /[^$\n\$]+/, Str::Heredoc
+        rule /[$]/, Str::Heredoc
+        mixin :strings
+      end
+
+      state :interpolation do
+        rule /\}/ do
+          token Keyword
+          pop!
+        end
+
+        mixin :expression
+      end
+
+      id = /[$a-z_\-][a-z0-9_\-]*/io
+
+      state :expression do
+        mixin :primitives
+        rule /\s+/, Text
+
+        rule %r(\+\+ | -- | ~ | && | \|\| | \\(?=\n) | << | >>>? | == | != )x, Operator
+        rule %r([-<>+*%&|\^/!=?:]=?), Operator
+        rule /[(\[,]/, Punctuation
+        rule /[)\].]/, Punctuation
+
+        rule id do |m|
+          if self.class.keywords.include? m[0]
+            token Keyword
+          elsif self.class.declarations.include? m[0]
+            token Keyword::Declaration
+          elsif self.class.reserved.include? m[0]
+            token Keyword::Reserved
+          elsif self.class.constants.include? m[0]
+            token Keyword::Constant
+          elsif self.class.builtins.include? m[0]
+            token Name::Builtin
+          else
+            token Name::Other
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lexers/terraform_spec.rb
+++ b/spec/lexers/terraform_spec.rb
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*- #
+
+describe Rouge::Lexers::Terraform do
+  let(:subject) { Rouge::Lexers::Terraform.new }
+
+  include Support::Lexing
+  it 'parses a basic Terraform file' do
+    tokens = subject.lex('terraform {}').to_a
+    assert { tokens.size == 3 }
+    assert { tokens.first[0] == Token['Keyword'] }
+  end
+
+  describe 'guessing' do
+    include Support::Guessing
+
+    it 'guesses by filename' do
+      assert_guess :filename => 'foo.tf'
+      deny_guess   :filename => 'foo'
+    end
+
+    it 'guesses by mimetype' do
+    end
+
+    it 'guesses by source' do
+    end
+  end
+end

--- a/spec/visual/samples/hcl
+++ b/spec/visual/samples/hcl
@@ -1,0 +1,1 @@
+# See Terraform lexer

--- a/spec/visual/samples/terraform
+++ b/spec/visual/samples/terraform
@@ -1,0 +1,326 @@
+# From https://github.com/terraform-providers/terraform-provider-aws/blob/master/examples/ecs-alb/main.tf
+
+# Specify the provider and access details
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+## EC2
+
+### Network
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.10.0.0/16"
+}
+
+resource "aws_subnet" "main" {
+  count             = "${var.az_count}"
+  cidr_block        = "${cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)}"
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+  vpc_id            = "${aws_vpc.main.id}"
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.main.id}"
+}
+
+resource "aws_route_table" "r" {
+  vpc_id = "${aws_vpc.main.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.gw.id}"
+  }
+}
+
+resource "aws_route_table_association" "a" {
+  count          = "${var.az_count}"
+  subnet_id      = "${element(aws_subnet.main.*.id, count.index)}"
+  route_table_id = "${aws_route_table.r.id}"
+}
+
+### Compute
+
+resource "aws_autoscaling_group" "app" {
+  name                 = "tf-test-asg"
+  vpc_zone_identifier  = ["${aws_subnet.main.*.id}"]
+  min_size             = "${var.asg_min}"
+  max_size             = "${var.asg_max}"
+  desired_capacity     = "${var.asg_desired}"
+  launch_configuration = "${aws_launch_configuration.app.name}"
+}
+
+data "template_file" "cloud_config" {
+  template = "${file("${path.module}/cloud-config.yml")}"
+
+  vars {
+    aws_region         = "${var.aws_region}"
+    ecs_cluster_name   = "${aws_ecs_cluster.main.name}"
+    ecs_log_level      = "info"
+    ecs_agent_version  = "latest"
+    ecs_log_group_name = "${aws_cloudwatch_log_group.ecs.name}"
+  }
+}
+
+data "aws_ami" "stable_coreos" {
+  most_recent = true
+
+  filter {
+    name   = "description"
+    values = ["CoreOS Container Linux stable *"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["595879546273"] # CoreOS
+}
+
+resource "aws_launch_configuration" "app" {
+  security_groups = [
+    "${aws_security_group.instance_sg.id}",
+  ]
+
+  key_name                    = "${var.key_name}"
+  image_id                    = "${data.aws_ami.stable_coreos.id}"
+  instance_type               = "${var.instance_type}"
+  iam_instance_profile        = "${aws_iam_instance_profile.app.name}"
+  user_data                   = "${data.template_file.cloud_config.rendered}"
+  associate_public_ip_address = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+### Security
+
+resource "aws_security_group" "lb_sg" {
+  description = "controls access to the application ELB"
+
+  vpc_id = "${aws_vpc.main.id}"
+  name   = "tf-ecs-lbsg"
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+}
+
+resource "aws_security_group" "instance_sg" {
+  description = "controls direct access to application instances"
+  vpc_id      = "${aws_vpc.main.id}"
+  name        = "tf-ecs-instsg"
+
+  ingress {
+    protocol  = "tcp"
+    from_port = 22
+    to_port   = 22
+
+    cidr_blocks = [
+      "${var.admin_cidr_ingress}",
+    ]
+  }
+
+  ingress {
+    protocol  = "tcp"
+    from_port = 8080
+    to_port   = 8080
+
+    security_groups = [
+      "${aws_security_group.lb_sg.id}",
+    ]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+## ECS
+
+resource "aws_ecs_cluster" "main" {
+  name = "terraform_example_ecs_cluster"
+}
+
+data "template_file" "task_definition" {
+  template = "${file("${path.module}/task-definition.json")}"
+
+  vars {
+    image_url        = "ghost:latest"
+    container_name   = "ghost"
+    log_group_region = "${var.aws_region}"
+    log_group_name   = "${aws_cloudwatch_log_group.app.name}"
+  }
+}
+
+resource "aws_ecs_task_definition" "ghost" {
+  family                = "tf_example_ghost_td"
+  container_definitions = "${data.template_file.task_definition.rendered}"
+}
+
+resource "aws_ecs_service" "test" {
+  name            = "tf-example-ecs-ghost"
+  cluster         = "${aws_ecs_cluster.main.id}"
+  task_definition = "${aws_ecs_task_definition.ghost.arn}"
+  desired_count   = 1
+  iam_role        = "${aws_iam_role.ecs_service.name}"
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.test.id}"
+    container_name   = "ghost"
+    container_port   = "2368"
+  }
+
+  depends_on = [
+    "aws_iam_role_policy.ecs_service",
+    "aws_alb_listener.front_end",
+  ]
+}
+
+## IAM
+
+resource "aws_iam_role" "ecs_service" {
+  name = "tf_example_ecs_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "ecs_service" {
+  name = "tf_example_ecs_policy"
+  role = "${aws_iam_role.ecs_service.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:Describe*",
+        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:Describe*",
+        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+        "elasticloadbalancing:RegisterTargets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "app" {
+  name = "tf-ecs-instprofile"
+  role = "${aws_iam_role.app_instance.name}"
+}
+
+resource "aws_iam_role" "app_instance" {
+  name = "tf-ecs-example-instance-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+data "template_file" "instance_profile" {
+  template = "${file("${path.module}/instance-profile-policy.json")}"
+
+  vars {
+    app_log_group_arn = "${aws_cloudwatch_log_group.app.arn}"
+    ecs_log_group_arn = "${aws_cloudwatch_log_group.ecs.arn}"
+  }
+}
+
+resource "aws_iam_role_policy" "instance" {
+  name   = "TfEcsExampleInstanceRole"
+  role   = "${aws_iam_role.app_instance.name}"
+  policy = "${data.template_file.instance_profile.rendered}"
+}
+
+## ALB
+
+resource "aws_alb_target_group" "test" {
+  name     = "tf-example-ecs-ghost"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${aws_vpc.main.id}"
+}
+
+resource "aws_alb" "main" {
+  name            = "tf-example-alb-ecs"
+  subnets         = ["${aws_subnet.main.*.id}"]
+  security_groups = ["${aws_security_group.lb_sg.id}"]
+}
+
+resource "aws_alb_listener" "front_end" {
+  load_balancer_arn = "${aws_alb.main.id}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_alb_target_group.test.id}"
+    type             = "forward"
+  }
+}
+
+## CloudWatch Logs
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  name = "tf-ecs-group/ecs-agent"
+}
+
+resource "aws_cloudwatch_log_group" "app" {
+  name = "tf-ecs-group/app-ghost"
+}


### PR DESCRIPTION
Fixes #722.

This implements two parts of the lexer, the HCL lexer implements most of the HCL language, and the Terraform lexer adds keywords and string interpolations.