### PR TITLE
Add supported .t extension for Perl

### DIFF
--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -9,7 +9,7 @@ module Rouge
       tag 'perl'
       aliases 'pl'
 
-      filenames '*.pl', '*.pm'
+      filenames '*.pl', '*.pm', '*.t'
       mimetypes 'text/x-perl', 'application/x-perl'
 
       def self.detect?(text)

--- a/spec/lexers/perl_spec.rb
+++ b/spec/lexers/perl_spec.rb
@@ -10,6 +10,7 @@ describe Rouge::Lexers::Perl do
       # *.pl needs source hints because it's also used by Prolog
       assert_guess :filename => 'foo.pl', :source => 'my $foo = 1'
       assert_guess :filename => 'foo.pm'
+      assert_guess :filename => 'test.t'
     end
 
     it 'guesses by mimetype' do


### PR DESCRIPTION
`.t` is a valid Perl extension for tests. https://perlmaven.com/testing-a-simple-perl-module