### PR TITLE
Add a mode flag to the CLI for dark/light

### DIFF
--- a/lib/rouge/cli.rb
+++ b/lib/rouge/cli.rb
@@ -309,12 +309,18 @@ module Rouge
         yield %|options:|
         yield %|  --scope	(default: .highlight) a css selector to scope by|
         yield %||
+        yield %|  --mode  (default: light) light themes are black on white and|
+        yield %|          dark themes are visa-versa|
+        yield %||
         yield %|available themes:|
         yield %|  #{Theme.registry.keys.sort.join(', ')}|
       end
 
       def self.parse(argv)
-        opts = { :theme_name => 'thankful_eyes' }
+        opts = {
+          theme_name: 'thankful_eyes',
+          mode: :light,
+        }
 
         until argv.empty?
           arg = argv.shift
@@ -331,8 +337,10 @@ module Rouge
 
       def initialize(opts)
         theme_name = opts.delete(:theme_name)
+        mode = opts.delete(:mode).to_sym
         theme_class = Theme.find(theme_name) \
           or error! "unknown theme: #{theme_name}"
+        theme_class = theme_class.mode(mode)
 
         @theme = theme_class.new(opts)
       end


### PR DESCRIPTION
This allows CLI users to generate CSS files that respect the light/dark mode.

```sh
rougify style base16 --mode dark
```

I only realized after creating this that the mode was controlled by `<theme>.<mode>` because some build in themes are called `<a>.<b>...`. I understand if you don't want to merge this, as it's somewhat redundant, but I thought I'd share it regardless.

Either way I have my dark themed CSS now :wink: 