### PR TITLE
improved escaping sequences for indented strings in nix lexer

### DIFF
--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -52,8 +52,8 @@ module Rouge
       end
 
       state :string do
-        rule /"/, Str::Double, :string_double_quoted
-        rule /''/, Str::Double, :string_indented
+        rule /"/, Str::Double, :double_quoted_string
+        rule /''/, Str::Double, :indented_string
       end
 
       state :string_content do
@@ -70,13 +70,13 @@ module Rouge
         rule /}/, Str::Interpol, :pop!
       end
 
-      state :string_indented do
+      state :indented_string do
         mixin :string_content
         rule /''/, Str::Double, :pop!
         rule /./, Str::Double
       end
 
-      state :string_double_quoted do
+      state :double_quoted_string do
         mixin :string_content
         rule /"/, Str::Double, :pop!
         rule /./, Str::Double

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -57,12 +57,15 @@ module Rouge
       end
 
       state :string_content do
+        rule /\\./, Str::Escape
         rule /\${/, Str::Interpol, :string_interpolated_arg
-        mixin :escaped_sequence
       end
 
-      state :escaped_sequence do
-        rule /\\./, Str::Escape
+      state :indented_string_content do
+        rule /'''/, Str::Escape
+        rule /''\$/, Str::Escape
+        rule /''\\./, Str::Escape
+        rule /\${/, Str::Interpol, :string_interpolated_arg
       end
 
       state :string_interpolated_arg do
@@ -71,7 +74,7 @@ module Rouge
       end
 
       state :indented_string do
-        mixin :string_content
+        mixin :indented_string_content
         rule /''/, Str::Double, :pop!
         rule /./, Str::Double
       end

--- a/lib/rouge/lexers/nix.rb
+++ b/lib/rouge/lexers/nix.rb
@@ -58,12 +58,14 @@ module Rouge
 
       state :string_content do
         rule /\\./, Str::Escape
+        rule /\$\$/, Str::Escape
         rule /\${/, Str::Interpol, :string_interpolated_arg
       end
 
       state :indented_string_content do
         rule /'''/, Str::Escape
         rule /''\$/, Str::Escape
+        rule /\$\$/, Str::Escape
         rule /''\\./, Str::Escape
         rule /\${/, Str::Interpol, :string_interpolated_arg
       end

--- a/spec/visual/samples/nix
+++ b/spec/visual/samples/nix
@@ -33,9 +33,12 @@ b > 10 && 42 >= 12
 
 "this is a string"
 
-"interpolated ${x}"
+"antiquotation ${toString (x + 7)}"
 
-"Escaped chars ${x} \n \r \t \${q}"
+"escaped chars \n \r \t \q \${q}"
+
+''escaped chars ''\n ''\r ''\t ''\q ''' ''${q}''
+++ ''raw chars " \n \r \t \q''
 
 # Examples from https://nixos.org/nix/manual/#idm140737318143152
 
@@ -43,13 +46,18 @@ b > 10 && 42 >= 12
 
 "--with-freetype2-library=" + freetype + "/lib"
 
-configureFlags = "
-  -system-zlib -system-libpng -system-libjpeg
-  ${if openglSupport then "-dlopen-opengl
-    -L${mesa}/lib -I${mesa}/include
-    -L${libXmu}/lib -I${libXmu}/include" else ""}
-  ${if threadSupport then "-thread" else "-no-thread"}
-";
+configureFlags = [
+  "-system-zlib"
+  "-system-libpng"
+  "-system-libjpeg"
+  (if threadSupport then "-thread" else "-no-thread")
+] ++ stdenv.lib.optionals openglSupport [
+  "-dlopen-opengl"
+  "-L${mesa}/lib"
+  "-I${mesa}/include"
+  "-L${libXmu}/lib"
+  "-I${libXmu}/include"
+];
 
 # indented string
 indented = ''
@@ -93,14 +101,23 @@ __variable__z_ = variable-y
 
 local/file
 
-https://nixos.org/nixos/manual/index.html
-git+https://nixos.org/nixos/manual/index.html
+./. # current directory
 
-file:///tmp/nixos
+/. # root directory
 
 ~ # not a path
 
+. # not a path
+
 / # not a path
+
+# uri
+
+https://nixos.org/nixos/manual/index.html
+
+git+https://nixos.org/nixos/manual/index.html
+
+file:///tmp/nixos
 
 # lists
 


### PR DESCRIPTION
Fixes: #924
```nix
let
  hello = throw "this will not be used";
  double_quoted = " \n \r \q \" ''\n \\ ";
  mystr = "foo";
in
  assert "\q" == "q";
  assert ''''\q'' == "q";
  assert "$${hello}" == "$" + "$" + "{hello}";
  assert ''$${hello}'' == "$" + "$" + "{hello}";
  assert "$$${mystr}" == "$" + "$" + mystr;
  assert ''$$${mystr}'' == "$" + "$" + mystr;
  ''
    First, rouge is missing antiquotes escaping:
     ''${hello} should not terminate the string
     $${hello} is another (strange) way to escape

    Then, indented strings can be escaped as using triple single quote:
     ''' should not terminate the string

    Indented strings also have different set of escape sequences:
     \n is not a line feed and should not be highligted as an escape
     ''\n is a line feed, it should not terminate the string
       (pygments doesn't seem to know that)
     ''\q will evaluate to just 'q', it should not terminate the string
       (both nix-mode and pygments don't seem to know that)
  ''
```
<img width="509" alt="image" src="https://user-images.githubusercontent.com/245573/41112490-23380d8c-6a4d-11e8-8754-e289c6d6c2f8.png">
