### PR TITLE
add "*.f" to fortran extensions

### DIFF
--- a/lib/rouge/lexers/fortran.rb
+++ b/lib/rouge/lexers/fortran.rb
@@ -10,8 +10,8 @@ module Rouge
       desc "Fortran 2008 (free-form)"
 
       tag 'fortran'
-      filenames '*.f90', '*.f95', '*.f03', '*.f08',
-                '*.F90', '*.F95', '*.F03', '*.F08'
+      filenames '*.f', '*.f90', '*.f95', '*.f03', '*.f08',
+                '*.F', '*.F90', '*.F95', '*.F03', '*.F08'
       mimetypes 'text/x-fortran'
 
       name = /[A-Z][_A-Z0-9]*/i


### PR DESCRIPTION
The original intent seemed to be to have separate lexers for different versions. It now mixes different fortran versions (95/2003/2008), so it seems natural to include the most common generic extension too.