### PR TITLE
make Python #-style comments parsed as Comment::Single

### DIFF
--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -68,7 +68,7 @@ module Rouge
         end
 
         rule /[^\S\n]+/, Text
-        rule /#.*$/, Comment
+        rule %r(#(.*)?\n), Comment::Single
         rule /[\[\]{}:(),;]/, Punctuation
         rule /\\\n/, Text
         rule /\\/, Text

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -68,7 +68,7 @@ module Rouge
         end
 
         rule /[^\S\n]+/, Text
-        rule %r(#(.*)?\n), Comment::Single
+        rule %r(#(.*)?\n?), Comment::Single
         rule /[\[\]{}:(),;]/, Punctuation
         rule /\\\n/, Text
         rule /\\/, Text


### PR DESCRIPTION
'#' comments are single line comments (kinda like // comments in C/C++). Rouge should strip the return line char and display them as such.

The same should be done for ruby.rb lexer I guess.

Before :

![image](https://user-images.githubusercontent.com/35742146/43002325-a153540e-8c28-11e8-9af1-28f3c252e23b.png)

After :


![image](https://user-images.githubusercontent.com/35742146/43002407-efc1a4d8-8c28-11e8-837d-952cdedbff37.png)
