### PR TITLE
Perl - Allow any non-whitespace character to delimit regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This log summarizes the changes in each released version of rouge. The versionin
 we use is semver, although we will often release new lexers in minor versions, as a
 practical matter.
 
+## version 3.2.1: (2018/08/16)
+
+https://github.com/jneen/rouge/compare/v3.2.0...v3.2.1
+
+* Perl Lexer
+  * Allow any non-whitespace character to delimit regexes ([#974](https://github.com/jneen/rouge/pull/974) by dblessing)
+    * Details: In specific cases where a previously unsupported regex delimiter was
+      used, a later rule could cause a backtrack in the regex system.
+      This resulted in Rouge hanging for an unspecified amount of time.
+
 ## version 3.2.0: (2018/08/02)
 
 https://github.com/jneen/rouge/compare/v3.1.1...v3.2.0

--- a/lib/rouge/lexers/perl.rb
+++ b/lib/rouge/lexers/perl.rb
@@ -77,11 +77,11 @@ module Rouge
         rule /(?:eq|lt|gt|le|ge|ne|not|and|or|cmp)\b/, Operator::Word
 
         # common delimiters
-        rule %r(s/(\\\\|\\/|[^/])*/(\\\\|\\/|[^/])*/[egimosx]*), re_tok
-        rule %r(s!(\\\\|\\!|[^!])*!(\\\\|\\!|[^!])*![egimosx]*), re_tok
-        rule %r(s\\(\\\\|[^\\])*\\(\\\\|[^\\])*\\[egimosx]*), re_tok
-        rule %r(s@(\\\\|\\@|[^@])*@(\\\\|\\@|[^@])*@[egimosx]*), re_tok
-        rule %r(s%(\\\\|\\%|[^%])*%(\\\\|\\%|[^%])*%[egimosx]*), re_tok
+        rule %r(s/(\\\\|\\/|[^/])*/(\\\\|\\/|[^/])*/[msixpodualngc]*), re_tok
+        rule %r(s!(\\\\|\\!|[^!])*!(\\\\|\\!|[^!])*![msixpodualngc]*), re_tok
+        rule %r(s\\(\\\\|[^\\])*\\(\\\\|[^\\])*\\[msixpodualngc]*), re_tok
+        rule %r(s@(\\\\|\\@|[^@])*@(\\\\|\\@|[^@])*@[msixpodualngc]*), re_tok
+        rule %r(s%(\\\\|\\%|[^%])*%(\\\\|\\%|[^%])*%[msixpodualngc]*), re_tok
 
         # balanced delimiters
         rule %r(s{(\\\\|\\}|[^}])*}\s*), re_tok, :balanced_regex
@@ -89,9 +89,13 @@ module Rouge
         rule %r(s\[(\\\\|\\\]|[^\]])*\]\s*), re_tok, :balanced_regex
         rule %r[s\((\\\\|\\\)|[^\)])*\)\s*], re_tok, :balanced_regex
 
-        rule %r(m?/(\\\\|\\/|[^/\n])*/[gcimosx]*), re_tok
+        rule %r(m?/(\\\\|\\/|[^/\n])*/[msixpodualngc]*), re_tok
         rule %r(m(?=[/!\\{<\[\(@%\$])), re_tok, :balanced_regex
-        rule %r(((?<==~)|(?<=\())\s*/(\\\\|\\/|[^/])*/[gcimosx]*),
+
+        # Perl allows any non-whitespace character to delimit
+        # a regex when `m` is used.
+        rule %r(m(\S).*\1[msixpodualngc]*), re_tok
+        rule %r(((?<==~)|(?<=\())\s*/(\\\\|\\/|[^/])*/[msixpodualngc]*),
           re_tok, :balanced_regex
 
         rule /\s+/, Text

--- a/lib/rouge/version.rb
+++ b/lib/rouge/version.rb
@@ -2,6 +2,6 @@
 
 module Rouge
   def self.version
-    "3.2.0"
+    "3.2.1"
   end
 end

--- a/spec/visual/samples/perl
+++ b/spec/visual/samples/perl
@@ -225,4 +225,8 @@ sub foo {
 
 # operators
 my $moduloOperation = $totalNumber % $columns ? 1 : 0;
+$moduloOperation = 2;
 my $addOperation = $totalNumber + $myOtherVar;
+
+# regexes delimited by non-standard (non-whitespace) character
+if $filename and $filename =~ m,usr/share/doc/[^/]+/examples/,;


### PR DESCRIPTION
In Perl, any non-whitespace character can be a regex delimiter. Obviously this doesn't allow
for that, but it does allow for a specific case seen recently where some Perl code had
a comma for a delimiter. In absence of this fix the lexer can get stuck later on other
rules.