### PR TITLE
Add = as Operator in Puppet lexer

### DIFF
--- a/lib/rouge/lexers/puppet.rb
+++ b/lib/rouge/lexers/puppet.rb
@@ -67,7 +67,7 @@ module Rouge
         rule /(in|and|or)\b/, Operator::Word
         rule /[=!<>]=/, Operator
         rule /[=!]~/, Operator, :regex_allowed
-        rule %r([<>!+*/-]), Operator
+        rule %r([=<>!+*/-]), Operator
 
         rule /(class|include)(\s*)(#{qualname})/ do
           groups Keyword, Text, Name::Class

--- a/spec/lexers/puppet_spec.rb
+++ b/spec/lexers/puppet_spec.rb
@@ -3,6 +3,55 @@
 describe Rouge::Lexers::Puppet do
   let(:subject) { Rouge::Lexers::Puppet.new }
 
+  describe 'lexing' do
+    include Support::Lexing
+
+    describe 'assignment' do
+      describe 'equals' do
+        it 'can assign a simple string' do
+          assert_tokens_equal "$foo = 'bar'",
+            ['Name.Variable', '$foo'],
+            ['Text', ' '],
+            ['Operator', '='],
+            ['Text', ' '],
+            ['Literal.String.Single', "'bar'"]
+        end
+
+        it 'can assign an array' do
+          assert_tokens_equal "$foo = [\n  'bar',\n  'baz',\n  ]",
+            ['Name.Variable', '$foo'],
+            ['Text', ' '],
+            ['Operator', '='],
+            ['Text', ' '],
+            ['Punctuation', '['],
+            ['Text', "\n  "],
+            ['Literal.String.Single', "'bar'"],
+            ['Punctuation', ','],
+            ['Text', "\n  "],
+            ['Literal.String.Single', "'baz'"],
+            ['Punctuation', ','],
+            ['Text', "\n  "],
+            ['Punctuation', ']']
+        end
+
+        it 'can assign a class variable Puppet 4 style' do
+          assert_tokens_equal "Array[String] $foo = $bar::baz::qux,",
+            ['Name.Class', 'Array'],    # Array[String] obviously is
+            ['Punctuation', '['],       # not really a Name.Class[Name.Class]!
+            ['Name.Class', 'String'],   # Puppet 4 Syntax highlighting seems
+            ['Punctuation', ']'],       # look okay by accident here.
+            ['Text', ' '],              #
+            ['Name.Variable', '$foo'],
+            ['Text', ' '],
+            ['Operator', '='],
+            ['Text', ' '],
+            ['Name.Variable', '$bar::baz::qux'],
+            ['Punctuation', ',']
+        end
+      end
+    end
+  end
+
   describe 'guessing' do
     include Support::Guessing
 

--- a/spec/lexers/puppet_spec.rb
+++ b/spec/lexers/puppet_spec.rb
@@ -3,55 +3,6 @@
 describe Rouge::Lexers::Puppet do
   let(:subject) { Rouge::Lexers::Puppet.new }
 
-  describe 'lexing' do
-    include Support::Lexing
-
-    describe 'assignment' do
-      describe 'equals' do
-        it 'can assign a simple string' do
-          assert_tokens_equal "$foo = 'bar'",
-            ['Name.Variable', '$foo'],
-            ['Text', ' '],
-            ['Operator', '='],
-            ['Text', ' '],
-            ['Literal.String.Single', "'bar'"]
-        end
-
-        it 'can assign an array' do
-          assert_tokens_equal "$foo = [\n  'bar',\n  'baz',\n  ]",
-            ['Name.Variable', '$foo'],
-            ['Text', ' '],
-            ['Operator', '='],
-            ['Text', ' '],
-            ['Punctuation', '['],
-            ['Text', "\n  "],
-            ['Literal.String.Single', "'bar'"],
-            ['Punctuation', ','],
-            ['Text', "\n  "],
-            ['Literal.String.Single', "'baz'"],
-            ['Punctuation', ','],
-            ['Text', "\n  "],
-            ['Punctuation', ']']
-        end
-
-        it 'can assign a class variable Puppet 4 style' do
-          assert_tokens_equal "Array[String] $foo = $bar::baz::qux,",
-            ['Name.Class', 'Array'],    # Array[String] obviously is
-            ['Punctuation', '['],       # not really a Name.Class[Name.Class]!
-            ['Name.Class', 'String'],   # Puppet 4 Syntax highlighting seems
-            ['Punctuation', ']'],       # look okay by accident here.
-            ['Text', ' '],              #
-            ['Name.Variable', '$foo'],
-            ['Text', ' '],
-            ['Operator', '='],
-            ['Text', ' '],
-            ['Name.Variable', '$bar::baz::qux'],
-            ['Punctuation', ',']
-        end
-      end
-    end
-  end
-
   describe 'guessing' do
     include Support::Guessing
 

--- a/spec/visual/samples/puppet
+++ b/spec/visual/samples/puppet
@@ -10,3 +10,12 @@ node /www\.example\.com/ {
     }
   }
 }
+
+class foo::bar (
+  Array[String] = foo::bar::baz,
+) {
+  $foo = [
+    'bar',
+    'baz',
+  ]
+}


### PR DESCRIPTION
The = sign had been missed apparently as a valid Puppet operator.
Fixes #979.