### PR TITLE
Add additional aliases for Rust

### DIFF
--- a/lib/rouge/lexers/rust.rb
+++ b/lib/rouge/lexers/rust.rb
@@ -6,7 +6,12 @@ module Rouge
       title "Rust"
       desc 'The Rust programming language (rust-lang.org)'
       tag 'rust'
-      aliases 'rs'
+      aliases 'rs',
+        # So that directives from https://github.com/budziq/rust-skeptic
+        # do not prevent highlighting.
+        'rust,no_run', 'rs,no_run',
+        'rust,ignore', 'rs,ignore',
+        'rust,should_panic', 'rs,should_panic'
       filenames '*.rs'
       mimetypes 'text/x-rust'
 


### PR DESCRIPTION
It is common for rust projects to use https://github.com/budziq/rust-skeptic
to test their code blocks in READMEs and markdown documents. Projects can configure `rust-skeptic`
by appending "no_run", "should_panic" or "ignore" at the start of the
block after "rust". Sadly, these directives make rouge not highlight anymore.

This change makes them continue to be highlighted even with those directives.