### PR TITLE
Kotlin: Recognise annotations and map to decorator

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -43,6 +43,7 @@ module Rouge
         rule %r'"(\\\\|\\"|[^"\n])*["\n]'m, Str
         rule %r"'\\.'|'[^\\]'", Str::Char
         rule %r"[0-9](\.[0-9]+)?([eE][+-][0-9]+)?[flFL]?|0[xX][0-9a-fA-F]+[Ll]?", Num
+        rule /@#{id}/, Name::Decorator
         rule %r'\b(companion)(\s+)(object)\b' do
           groups Keyword, Text, Keyword
         end

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -22,9 +22,5 @@ describe Rouge::Lexers::Kotlin do
     it 'recognizes one-line comments not followed by a newline (#797)' do
       assert_tokens_equal '// comment', ['Comment.Single', '// comment']
     end
-
-    it 'recognizes annotations' do
-      assert_tokens_equal '@Deprecated', ['Name.Decorator', '@Deprecated']
-    end
   end
 end

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -22,5 +22,9 @@ describe Rouge::Lexers::Kotlin do
     it 'recognizes one-line comments not followed by a newline (#797)' do
       assert_tokens_equal '// comment', ['Comment.Single', '// comment']
     end
+
+    it 'recognizes annotations' do
+      assert_tokens_equal '@Deprecated', ['Name.Decorator', '@Deprecated']
+    end
   end
 end

--- a/spec/visual/samples/kotlin
+++ b/spec/visual/samples/kotlin
@@ -140,4 +140,8 @@ fun <T, V> String.genericExtensionFunction() {
    return
 }
 
+@Deprecated("This is an annotation")
+fun anAnnotatedFunction() = {
+}
+
 // comment at EOF (#797)


### PR DESCRIPTION
This matches Java's handling, mapping an annotation like @Deprecated to Name::Decorator.

Added example to the visual sample and unit test.

Fixes #994.