### PR TITLE
Kotlin: Recognizing function parameters and return type

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -57,6 +57,13 @@ module Rouge
           groups Keyword, Text
           push :function
         end
+        rule %r'(#{name_backtick})(:)(\s+)(#{name_backtick})(<)' do
+          groups Name::Variable, Punctuation, Text, Name::Class, Punctuation
+          push :generic_parameters
+        end
+        rule %r'(#{name_backtick})(:)(\s+)(#{name_backtick})' do
+          groups Name::Variable, Punctuation, Text, Name::Class
+        end
         rule %r'\b(package|import)(\s+)' do
           groups Keyword, Text
           push :package
@@ -92,6 +99,10 @@ module Rouge
         rule %r'(,)', Punctuation
         rule %r'(\s+)', Text
         rule %r'(>)', Punctuation, :pop!
+      end
+
+      state :function_parameter do
+
       end
 
       state :property do

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -30,7 +30,13 @@ module Rouge
       id = %r'(#{name_backtick})'
 
       state :root do
-        rule /@#{id}/, Name::Decorator
+        rule %r'(\))(\s*)(:)(\s+)(#{name_backtick})(<)' do
+          groups Punctuation, Text, Punctuation, Text, Name::Class, Punctuation
+          push :generic_parameters
+        end
+        rule %r'(\))(\s*)(:)(\s+)(#{name_backtick})' do
+          groups Punctuation, Text, Punctuation, Text, Name::Class
+        end
         rule %r'\b(companion)(\s+)(object)\b' do
           groups Keyword, Text, Keyword
         end
@@ -74,6 +80,7 @@ module Rouge
         rule %r'"(\\\\|\\"|[^"\n])*["\n]'m, Str
         rule %r"'\\.'|'[^\\]'", Str::Char
         rule %r"[0-9](\.[0-9]+)?([eE][+-][0-9]+)?[flFL]?|0[xX][0-9a-fA-F]+[Ll]?", Num
+        rule /@#{id}/, Name::Decorator
         rule id, Name
       end
 
@@ -99,10 +106,6 @@ module Rouge
         rule %r'(,)', Punctuation
         rule %r'(\s+)', Text
         rule %r'(>)', Punctuation, :pop!
-      end
-
-      state :function_parameter do
-
       end
 
       state :property do

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -30,21 +30,6 @@ module Rouge
       id = %r'(#{name_backtick})'
 
       state :root do
-        rule %r'^\s*\[.*?\]', Name::Attribute
-        rule %r'[^\S\n]+', Text
-        rule %r'\\\n', Text # line continuation
-        rule %r'//.*?$', Comment::Single
-        rule %r'/[*].*?[*]/'m, Comment::Multiline
-        rule %r'\n', Text
-        rule %r'::|!!|\?[:.]', Operator
-        rule %r"(\.\.)", Operator
-        rule %r'[~!%^&*()+=|\[\]:;,.<>/?-]', Punctuation
-        rule %r'[{}]', Punctuation
-        rule %r'@"(""|[^"])*"'m, Str
-        rule %r'""".*?"""'m, Str
-        rule %r'"(\\\\|\\"|[^"\n])*["\n]'m, Str
-        rule %r"'\\.'|'[^\\]'", Str::Char
-        rule %r"[0-9](\.[0-9]+)?([eE][+-][0-9]+)?[flFL]?|0[xX][0-9a-fA-F]+[Ll]?", Num
         rule /@#{id}/, Name::Decorator
         rule %r'\b(companion)(\s+)(object)\b' do
           groups Keyword, Text, Keyword
@@ -74,6 +59,21 @@ module Rouge
         end
         rule %r/\bfun\b/, Keyword
         rule /\b(?:#{keywords.join('|')})\b/, Keyword
+        rule %r'^\s*\[.*?\]', Name::Attribute
+        rule %r'[^\S\n]+', Text
+        rule %r'\\\n', Text # line continuation
+        rule %r'//.*?$', Comment::Single
+        rule %r'/[*].*?[*]/'m, Comment::Multiline
+        rule %r'\n', Text
+        rule %r'::|!!|\?[:.]', Operator
+        rule %r"(\.\.)", Operator
+        rule %r'[~!%^&*()+=|\[\]:;,.<>/?-]', Punctuation
+        rule %r'[{}]', Punctuation
+        rule %r'@"(""|[^"])*"'m, Str
+        rule %r'""".*?"""'m, Str
+        rule %r'"(\\\\|\\"|[^"\n])*["\n]'m, Str
+        rule %r"'\\.'|'[^\\]'", Str::Char
+        rule %r"[0-9](\.[0-9]+)?([eE][+-][0-9]+)?[flFL]?|0[xX][0-9a-fA-F]+[Ll]?", Num
         rule id, Name
       end
 


### PR DESCRIPTION
This is a follow up PR after #996. To allow this to be implemented it was branched from that branch.

- Function parameters
- Generic parameter types such as 'Array<String>'
- Return type
- Generic return type

Fixes #997 and #998.