### PR TITLE
Kotlin: Recognize destructuring assignment

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -29,21 +29,6 @@ module Rouge
       id = %r'(#{name_backtick})'
 
       state :root do
-        rule %r'^\s*\[.*?\]', Name::Attribute
-        rule %r'[^\S\n]+', Text
-        rule %r'\\\n', Text # line continuation
-        rule %r'//.*?$', Comment::Single
-        rule %r'/[*].*?[*]/'m, Comment::Multiline
-        rule %r'\n', Text
-        rule %r'::|!!|\?[:.]', Operator
-        rule %r"(\.\.)", Operator
-        rule %r'[~!%^&*()+=|\[\]:;,.<>/?-]', Punctuation
-        rule %r'[{}]', Punctuation
-        rule %r'@"(""|[^"])*"'m, Str
-        rule %r'""".*?"""'m, Str
-        rule %r'"(\\\\|\\"|[^"\n])*["\n]'m, Str
-        rule %r"'\\.'|'[^\\]'", Str::Char
-        rule %r"[0-9](\.[0-9]+)?([eE][+-][0-9]+)?[flFL]?|0[xX][0-9a-fA-F]+[Ll]?", Num
         rule %r'\b(companion)(\s+)(object)\b' do
           groups Keyword, Text, Keyword
         end
@@ -72,6 +57,21 @@ module Rouge
         end
         rule %r/\bfun\b/, Keyword
         rule /\b(?:#{keywords.join('|')})\b/, Keyword
+        rule %r'^\s*\[.*?\]', Name::Attribute
+        rule %r'[^\S\n]+', Text
+        rule %r'\\\n', Text # line continuation
+        rule %r'//.*?$', Comment::Single
+        rule %r'/[*].*?[*]/'m, Comment::Multiline
+        rule %r'\n', Text
+        rule %r'::|!!|\?[:.]', Operator
+        rule %r"(\.\.)", Operator
+        rule %r'[~!%^&*()+=|\[\]:;,.<>/?-]', Punctuation
+        rule %r'[{}]', Punctuation
+        rule %r'@"(""|[^"])*"'m, Str
+        rule %r'""".*?"""'m, Str
+        rule %r'"(\\\\|\\"|[^"\n])*["\n]'m, Str
+        rule %r"'\\.'|'[^\\]'", Str::Char
+        rule %r"[0-9](\.[0-9]+)?([eE][+-][0-9]+)?[flFL]?|0[xX][0-9a-fA-F]+[Ll]?", Num
         rule id, Name
       end
 

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -50,6 +50,19 @@ module Rouge
           groups Keyword::Declaration, Text
           push :class
         end
+        rule %r'\b(fun)(\s+)(<[a-zA-Z0-9]+(?:(?:,\s*[a-zA-Z0-9]+)*)>)(\s+)([a-zA-Z0-9]+)(\()' do
+          groups Keyword, Text, Text, Text, Name::Function, Punctuation
+        end
+        rule %r'\b(fun)(\s+)(<[a-zA-Z0-9]+(?:(?:,\s*[a-zA-Z0-9]+)*)>)(\s+)([a-zA-Z0-9]+)(\.)([a-zA-Z0-9]+)(\()' do
+          groups Keyword, Text, Text, Text, Name::Class, Punctuation, Name::Function, Punctuation
+        end
+        rule %r'\b(fun)(\s+)([a-zA-Z0-9]+)(\.)([a-zA-Z0-9]+)(\()' do
+          groups Keyword, Text, Name::Class, Punctuation, Name::Function, Punctuation
+        end
+        rule %r'\b(fun)(\s+)' do
+          groups Keyword, Text
+          push :function
+        end
         rule %r'\b(package|import)(\s+)' do
           groups Keyword, Text
           push :package
@@ -58,7 +71,6 @@ module Rouge
           groups Keyword::Declaration, Text
           push :property
         end
-        rule %r/\bfun\b/, Keyword
         rule /\b(?:#{keywords.join('|')})\b/, Keyword
         rule id, Name
       end
@@ -69,6 +81,10 @@ module Rouge
 
       state :class do
         rule id, Name::Class, :pop!
+      end
+
+      state :function do
+        rule id, Name::Function, :pop!
       end
 
       state :property do

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -29,6 +29,10 @@ module Rouge
       id = %r'(#{name_backtick})'
 
       state :root do
+        rule %r'(\))(\s*)(:)(\s+)(#{name_backtick})(<)' do
+          groups Punctuation, Text, Punctuation, Text, Name::Class, Punctuation
+          push :generic_parameters
+        end
         rule %r'(\))(\s*)(:)(\s+)(#{name_backtick})' do
           groups Punctuation, Text, Punctuation, Text, Name::Class
         end

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -82,7 +82,13 @@ module Rouge
         rule %r'(#{name_backtick})(\.)' do
           groups Name::Class, Punctuation
         end
-        rule id, Name::Function, :pop!
+        rule %r'(\()', Punctuation, :function_parameters
+        rule %r'(:)(\s+)(#{name_backtick})' do
+          groups Punctuation, Text, Name::Class
+        end
+        rule %r'(\{)', Punctuation, :pop!
+        rule %r'(\=)', Punctuation, :pop!
+        rule id, Name::Function
       end
 
       state :generic_parameters do
@@ -90,6 +96,16 @@ module Rouge
         rule %r'(,)', Punctuation
         rule %r'(\s+)', Text
         rule %r'(>)', Punctuation, :pop!
+      end
+
+      state :function_parameters do
+        rule %r'(,)', Punctuation
+        rule %r'(\s+)', Text
+        rule %r'(@#{name_backtick})'
+        rule %r'(#{name_backtick})(\s*)(:)(\s*)(#{name_backtick})' do
+          groups Name::Variable, Text, Punctuation, Text, Name::Class
+        end
+        rule %r'\)', Punctuation, :pop!
       end
 
       state :property do

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -29,6 +29,9 @@ module Rouge
       id = %r'(#{name_backtick})'
 
       state :root do
+        rule %r'(\))(\s*)(:)(\s+)(#{name_backtick})' do
+          groups Punctuation, Text, Punctuation, Text, Name::Class
+        end
         rule %r'\b(companion)(\s+)(object)\b' do
           groups Keyword, Text, Keyword
         end

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -50,15 +50,6 @@ module Rouge
           groups Keyword::Declaration, Text
           push :class
         end
-        # rule %r'\b(fun)(\s+)(<[a-zA-Z0-9]+(?:(?:,\s*[a-zA-Z0-9]+)*)>)(\s+)([a-zA-Z0-9]+)(\()' do
-        #   groups Keyword, Text, Text, Text, Name::Function, Punctuation
-        # end
-        # rule %r'\b(fun)(\s+)(<[a-zA-Z0-9]+(?:(?:,\s*[a-zA-Z0-9]+)*)>)(\s+)([a-zA-Z0-9]+)(\.)([a-zA-Z0-9]+)(\()' do
-        #   groups Keyword, Text, Text, Text, Name::Class, Punctuation, Name::Function, Punctuation
-        # end
-        # rule %r'\b(fun)(\s+)([a-zA-Z0-9]+)(\.)([a-zA-Z0-9]+)(\()' do
-        #   groups Keyword, Text, Name::Class, Punctuation, Name::Function, Punctuation
-        # end
         rule %r'\b(fun)(\s+)' do
           groups Keyword, Text
           push :function
@@ -87,6 +78,9 @@ module Rouge
       state :function do
         rule %r'(<)(#{name}(?:(?:,\s*#{name})*))(>)(\s+)' do
           groups Punctuation, Text, Punctuation, Text
+        end
+        rule %r'(#{name})(\.)' do
+          groups Name::Class, Punctuation
         end
         rule id, Name::Function, :pop!
       end

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -55,6 +55,13 @@ module Rouge
           groups Keyword, Text
           push :function
         end
+        rule %r'(#{name_backtick})(:)(\s+)(#{name_backtick})(<)' do
+          groups Name::Variable, Punctuation, Text, Name::Class, Punctuation
+          push :generic_parameters
+        end
+        rule %r'(#{name_backtick})(:)(\s+)(#{name_backtick})' do
+          groups Name::Variable, Punctuation, Text, Name::Class
+        end
         rule %r'\b(package|import)(\s+)' do
           groups Keyword, Text
           push :package
@@ -82,13 +89,7 @@ module Rouge
         rule %r'(#{name_backtick})(\.)' do
           groups Name::Class, Punctuation
         end
-        rule %r'(\()', Punctuation, :function_parameters
-        rule %r'(:)(\s+)(#{name_backtick})' do
-          groups Punctuation, Text, Name::Class
-        end
-        rule %r'(\{)', Punctuation, :pop!
-        rule %r'(\=)', Punctuation, :pop!
-        rule id, Name::Function
+        rule id, Name::Function, :pop!
       end
 
       state :generic_parameters do
@@ -98,14 +99,8 @@ module Rouge
         rule %r'(>)', Punctuation, :pop!
       end
 
-      state :function_parameters do
-        rule %r'(,)', Punctuation
-        rule %r'(\s+)', Text
-        rule %r'(@#{name_backtick})'
-        rule %r'(#{name_backtick})(\s*)(:)(\s*)(#{name_backtick})' do
-          groups Name::Variable, Text, Punctuation, Text, Name::Class
-        end
-        rule %r'\)', Punctuation, :pop!
+      state :function_parameter do
+
       end
 
       state :property do

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -58,6 +58,10 @@ module Rouge
           groups Keyword, Text
           push :package
         end
+        rule %r'\b(val|var)(\s+)(\()' do
+          groups Keyword::Declaration, Text, Punctuation
+          push :destructure
+        end
         rule %r'\b(val|var)(\s+)' do
           groups Keyword::Declaration, Text
           push :property
@@ -112,6 +116,13 @@ module Rouge
 
       state :property do
         rule id, Name::Property, :pop!
+      end
+
+      state :destructure do
+        rule %r'(,)', Punctuation
+        rule %r'(\))', Punctuation, :pop!
+        rule %r'(\s+)', Text
+        rule id, Name::Property
       end
     end
   end

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -24,8 +24,9 @@ module Rouge
       )
 
       name = %r'@?[_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}][\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*'
+      name_backtick = %r'#{name}|`#{name}`'
 
-      id = %r'(#{name}|`#{name}`)'
+      id = %r'(#{name_backtick})'
 
       state :root do
         rule %r'^\s*\[.*?\]', Name::Attribute
@@ -76,10 +77,10 @@ module Rouge
       end
 
       state :function do
-        rule %r'(<)(#{name}(?:(?:,\s*#{name})*))(>)(\s+)' do
+        rule %r'(<)(#{name_backtick}(?:(?:,\s*#{name_backtick})*))(>)(\s+)' do
           groups Punctuation, Text, Punctuation, Text
         end
-        rule %r'(#{name})(\.)' do
+        rule %r'(#{name_backtick})(\.)' do
           groups Name::Class, Punctuation
         end
         rule id, Name::Function, :pop!

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -77,13 +77,19 @@ module Rouge
       end
 
       state :function do
-        rule %r'(<)(#{name_backtick}(?:(?:,\s*#{name_backtick})*))(>)(\s+)' do
-          groups Punctuation, Text, Punctuation, Text
-        end
+        rule %r'(<)', Punctuation, :generic_parameters
+        rule %r'(\s+)', Text
         rule %r'(#{name_backtick})(\.)' do
           groups Name::Class, Punctuation
         end
         rule id, Name::Function, :pop!
+      end
+
+      state :generic_parameters do
+        rule id, Name::Class
+        rule %r'(,)', Punctuation
+        rule %r'(\s+)', Text
+        rule %r'(>)', Punctuation, :pop!
       end
 
       state :property do

--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -50,15 +50,15 @@ module Rouge
           groups Keyword::Declaration, Text
           push :class
         end
-        rule %r'\b(fun)(\s+)(<[a-zA-Z0-9]+(?:(?:,\s*[a-zA-Z0-9]+)*)>)(\s+)([a-zA-Z0-9]+)(\()' do
-          groups Keyword, Text, Text, Text, Name::Function, Punctuation
-        end
-        rule %r'\b(fun)(\s+)(<[a-zA-Z0-9]+(?:(?:,\s*[a-zA-Z0-9]+)*)>)(\s+)([a-zA-Z0-9]+)(\.)([a-zA-Z0-9]+)(\()' do
-          groups Keyword, Text, Text, Text, Name::Class, Punctuation, Name::Function, Punctuation
-        end
-        rule %r'\b(fun)(\s+)([a-zA-Z0-9]+)(\.)([a-zA-Z0-9]+)(\()' do
-          groups Keyword, Text, Name::Class, Punctuation, Name::Function, Punctuation
-        end
+        # rule %r'\b(fun)(\s+)(<[a-zA-Z0-9]+(?:(?:,\s*[a-zA-Z0-9]+)*)>)(\s+)([a-zA-Z0-9]+)(\()' do
+        #   groups Keyword, Text, Text, Text, Name::Function, Punctuation
+        # end
+        # rule %r'\b(fun)(\s+)(<[a-zA-Z0-9]+(?:(?:,\s*[a-zA-Z0-9]+)*)>)(\s+)([a-zA-Z0-9]+)(\.)([a-zA-Z0-9]+)(\()' do
+        #   groups Keyword, Text, Text, Text, Name::Class, Punctuation, Name::Function, Punctuation
+        # end
+        # rule %r'\b(fun)(\s+)([a-zA-Z0-9]+)(\.)([a-zA-Z0-9]+)(\()' do
+        #   groups Keyword, Text, Name::Class, Punctuation, Name::Function, Punctuation
+        # end
         rule %r'\b(fun)(\s+)' do
           groups Keyword, Text
           push :function
@@ -71,6 +71,7 @@ module Rouge
           groups Keyword::Declaration, Text
           push :property
         end
+        rule %r/\bfun\b/, Keyword
         rule /\b(?:#{keywords.join('|')})\b/, Keyword
         rule id, Name
       end
@@ -84,6 +85,9 @@ module Rouge
       end
 
       state :function do
+        rule %r'(<)(#{name}(?:(?:,\s*#{name})*))(>)(\s+)' do
+          groups Punctuation, Text, Punctuation, Text
+        end
         rule id, Name::Function, :pop!
       end
 

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -22,5 +22,71 @@ describe Rouge::Lexers::Kotlin do
     it 'recognizes one-line comments not followed by a newline (#797)' do
       assert_tokens_equal '// comment', ['Comment.Single', '// comment']
     end
+
+    describe 'functions' do
+      
+      it 'recognizes function' do
+        assert_tokens_equal 'fun makeField()',
+          ['Keyword', 'fun'],
+          ['Text', " "],
+          ['Name.Function', 'makeField'],
+          ['Punctuation', '()']
+      end
+
+      it 'recognizes backticked function' do
+        assert_tokens_equal 'fun `makeField`()',
+          ['Keyword', 'fun'],
+          ['Text', " "],
+          ['Name.Function', '`makeField`'],
+          ['Punctuation', '()']
+      end
+
+      it 'recognizes extension function' do
+        assert_tokens_equal 'fun String.makeField()',
+          ['Keyword', 'fun'],
+          ['Text', " "],
+          ['Name.Class', 'String'],
+          ['Punctuation', '.'],
+          ['Name.Function', 'makeField'],
+          ['Punctuation', '()']
+      end
+
+      it 'recognizes backticked extension function' do
+        assert_tokens_equal 'fun `String`.`makeField`()',
+          ['Keyword', 'fun'],
+          ['Text', " "],
+          ['Name.Class', '`String`'],
+          ['Punctuation', '.'],
+          ['Name.Function', '`makeField`'],
+          ['Punctuation', '()']
+      end
+
+      it 'recognizes generic function' do
+        assert_tokens_equal 'fun <T, ClassT> makeField()',
+          ['Keyword', 'fun'],
+          ['Text', " "],
+          ['Punctuation', '<'],
+          ['Text', 'T, ClassT'],
+          ['Punctuation', '>'],
+          ['Text', " "],
+          ['Name.Function', 'makeField'],
+          ['Punctuation', '()']
+      end
+
+      it 'recognizes generic extension function' do
+        assert_tokens_equal 'fun <T, ClassT> String.makeField()',
+          ['Keyword', 'fun'],
+          ['Text', " "],
+          ['Punctuation', '<'],
+          ['Text', 'T, ClassT'],
+          ['Punctuation', '>'],
+          ['Text', " "],
+          ['Name.Class', 'String'],
+          ['Punctuation', '.'],
+          ['Name.Function', 'makeField'],
+          ['Punctuation', '()']
+      end
+
+    end
   end
 end

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -93,6 +93,16 @@ describe Rouge::Lexers::Kotlin do
           ['Punctuation', '()']
       end
 
+      it 'recognizes function return type' do
+        assert_tokens_equal 'fun makeField(): String',
+          ['Keyword', 'fun'],
+          ['Text', " "],
+          ['Name.Function', 'makeField'],
+          ['Punctuation', '():'],
+          ['Text', " "],
+          ['Name.Class', 'String']
+      end
+
     end
   end
 end

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -24,7 +24,7 @@ describe Rouge::Lexers::Kotlin do
     end
 
     describe 'functions' do
-      
+
       it 'recognizes function' do
         assert_tokens_equal 'fun makeField()',
           ['Keyword', 'fun'],
@@ -66,7 +66,10 @@ describe Rouge::Lexers::Kotlin do
           ['Keyword', 'fun'],
           ['Text', " "],
           ['Punctuation', '<'],
-          ['Text', 'T, ClassT'],
+          ['Name.Class', 'T'],
+          ['Punctuation', ','],
+          ['Text', " "],
+          ['Name.Class', 'ClassT'],
           ['Punctuation', '>'],
           ['Text', " "],
           ['Name.Function', 'makeField'],
@@ -78,7 +81,10 @@ describe Rouge::Lexers::Kotlin do
           ['Keyword', 'fun'],
           ['Text', " "],
           ['Punctuation', '<'],
-          ['Text', 'T, ClassT'],
+          ['Name.Class', 'T'],
+          ['Punctuation', ','],
+          ['Text', " "],
+          ['Name.Class', 'ClassT'],
           ['Punctuation', '>'],
           ['Text', " "],
           ['Name.Class', 'String'],

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -112,6 +112,21 @@ describe Rouge::Lexers::Kotlin do
           ['Punctuation', ')']
       end
 
+      it 'recognizes function with a generic parameter' do
+        assert_tokens_equal 'fun makeField(thing: Array<String>)',
+          ['Keyword', 'fun'],
+          ['Text', " "],
+          ['Name.Function', 'makeField'],
+          ['Punctuation', '('],
+          ['Name.Variable', 'thing'],
+          ['Punctuation', ':'],
+          ['Text', " "],
+          ['Name.Class', 'Array'],
+          ['Punctuation', '<'],
+          ['Name.Class', "String"],
+          ['Punctuation', '>)']
+      end
+
       it 'recognizes function return type' do
         assert_tokens_equal 'fun makeField(): String',
           ['Keyword', 'fun'],

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -137,6 +137,19 @@ describe Rouge::Lexers::Kotlin do
           ['Name.Class', 'String']
       end
 
+      it 'recognizes function return generic type' do
+        assert_tokens_equal 'fun makeField(): Array<String>',
+          ['Keyword', 'fun'],
+          ['Text', " "],
+          ['Name.Function', 'makeField'],
+          ['Punctuation', '():'],
+          ['Text', " "],
+          ['Name.Class', 'Array'],
+          ['Punctuation', '<'],
+          ['Name.Class', 'String'],
+          ['Punctuation', '>']
+      end
+
     end
   end
 end

--- a/spec/lexers/kotlin_spec.rb
+++ b/spec/lexers/kotlin_spec.rb
@@ -93,6 +93,25 @@ describe Rouge::Lexers::Kotlin do
           ['Punctuation', '()']
       end
 
+      it 'recognizes function parameters' do
+        assert_tokens_equal 'fun makeField(thing: Int, other: String)',
+          ['Keyword', 'fun'],
+          ['Text', " "],
+          ['Name.Function', 'makeField'],
+          ['Punctuation', '('],
+          ['Name.Variable', 'thing'],
+          ['Punctuation', ':'],
+          ['Text', " "],
+          ['Name.Class', 'Int'],
+          ['Punctuation', ','],
+          ['Text', " "],
+          ['Name.Variable', 'other'],
+          ['Punctuation', ':'],
+          ['Text', " "],
+          ['Name.Class', 'String'],
+          ['Punctuation', ')']
+      end
+
       it 'recognizes function return type' do
         assert_tokens_equal 'fun makeField(): String',
           ['Keyword', 'fun'],

--- a/spec/visual/samples/kotlin
+++ b/spec/visual/samples/kotlin
@@ -140,4 +140,6 @@ fun <T, V> String.genericExtensionFunction() {
    return
 }
 
+val (a, b) = pair
+
 // comment at EOF (#797)


### PR DESCRIPTION
Maps the destructured properties to Name.Property.

Fixes #885.