### PR TITLE
Kotlin: Recognize destructuring assignment

### DIFF
--- a/lib/rouge/lexers/kotlin.rb
+++ b/lib/rouge/lexers/kotlin.rb
@@ -61,6 +61,10 @@ module Rouge
           groups Keyword, Text
           push :package
         end
+        rule %r'\b(val|var)(\s+)(\()' do
+          groups Keyword::Declaration, Text, Punctuation
+          push :destructure
+        end
         rule %r'\b(val|var)(\s+)' do
           groups Keyword::Declaration, Text
           push :property
@@ -96,6 +100,13 @@ module Rouge
 
       state :property do
         rule id, Name::Property, :pop!
+      end
+
+      state :destructure do
+        rule %r'(,)', Punctuation
+        rule %r'(\))', Punctuation, :pop!
+        rule %r'(\s+)', Text
+        rule id, Name::Property
       end
     end
   end

--- a/spec/visual/samples/kotlin
+++ b/spec/visual/samples/kotlin
@@ -152,4 +152,6 @@ fun <T, V> String.genericExtensionFunction() {
 fun anAnnotatedFunction() = {
 }
 
+val (a, b) = pair
+
 // comment at EOF (#797)


### PR DESCRIPTION
Maps the destructured properties to Name.Property.

Fixes #885.