### PR TITLE
Add `Dangerfile` as ruby filename

### DIFF
--- a/lib/rouge/lexers/ruby.rb
+++ b/lib/rouge/lexers/ruby.rb
@@ -10,7 +10,8 @@ module Rouge
       aliases 'rb'
       filenames '*.rb', '*.ruby', '*.rbw', '*.rake', '*.gemspec', '*.podspec',
                 'Rakefile', 'Guardfile', 'Gemfile', 'Capfile', 'Podfile',
-                'Vagrantfile', '*.ru', '*.prawn', 'Berksfile', '*.arb'
+                'Vagrantfile', '*.ru', '*.prawn', 'Berksfile', '*.arb',
+                'Dangerfile'
 
       mimetypes 'text/x-ruby', 'application/x-ruby'
 


### PR DESCRIPTION
[Danger][1] is a gem which runs ruby code defined in a `Dangerfile`.

There are several examples of it available online [2], [3]. The syntax
highlighting on GH properly detects them. So rouge probably should as well.

[1]: https://danger.systems/ruby/
[2]: https://github.com/samdmarshall/danger/blob/master/Dangerfile
[3]: https://github.com/artsy/eigen/blob/master/Dangerfile