### PR TITLE
Add = to Jinja operators

### DIFF
--- a/lib/rouge/lexers/jinja.rb
+++ b/lib/rouge/lexers/jinja.rb
@@ -82,7 +82,7 @@ module Rouge
 
         # Arithmetic operators (+, -, *, **, //, /)
         # TODO : implement modulo (%)
-        rule /(\+|\-|\*|\/\/?|\*\*?)/, Operator
+        rule /(\+|\-|\*|\/\/?|\*\*?|=)/, Operator
 
         # Comparisons operators (<=, <, >=, >, ==, ===, !=)
         rule /(<=?|>=?|===?|!=)/, Operator

--- a/spec/visual/samples/jinja
+++ b/spec/visual/samples/jinja
@@ -7,6 +7,9 @@
 {% endfor %}
 </ul>
 
+{% set navigation = [('index.html', 'Index'), ('about.html', 'About')] %}
+{% set key, value = call_something() %}
+
 {# A comment #}
 
 Hello {{ user.name|capitalize }} !


### PR DESCRIPTION
Fixes #1010 

Add `=` to Jinja operators. Otherwise assigning values in a `{% set %}` tag will yield an error token. 