### PR TITLE
GraphQL: Support for multiline strings

### DIFF
--- a/lib/rouge/lexers/graphql.rb
+++ b/lib/rouge/lexers/graphql.rb
@@ -227,6 +227,9 @@ module Rouge
           }
         }
 
+        # Multiline strings
+        rule /""".*?"""/m, Str::Double
+
         rule /\$#{name}\b/, &pop_unless_list[Name::Variable]
         rule /\b(?:true|false|null)\b/, &pop_unless_list[Keyword::Constant]
         rule /[+-]?[0-9]+\.[0-9]+(?:[eE][+-]?[0-9]+)?/, &pop_unless_list[Num::Float]

--- a/lib/rouge/lexers/graphql.rb
+++ b/lib/rouge/lexers/graphql.rb
@@ -27,6 +27,13 @@ module Rouge
         rule /\bunion\b/, Keyword, :union_definition
 
         mixin :basic
+
+        # Markdown descriptions
+        rule /(""")(.*?)(""")/m do |m|
+          token Str::Double, m[1]
+          delegate Markdown, m[2]
+          token Str::Double, m[3]
+        end
       end
 
       state :basic do

--- a/spec/visual/samples/graphql
+++ b/spec/visual/samples/graphql
@@ -1,3 +1,23 @@
+"""
+Decimal number serialized as string.
+
+Should match regexp: `/^[+-]?[0-9]+(\.[0-9]+)$/`
+
+Format:
+  `<sign>`? `<digit>`+ ( `.` `<digit>`+ )?
+
+Example:
+ - `"1000"`
+ - `"0.00000001"`
+ - `"-10"`
+ - `"+1"`
+
+This is invalid:
+ - `".01"` *missing preceding zero*
+ - `"1,000.00"` *invalid character*
+ - `"1e-10"` *exponential form is not allowed*
+"""
+
 # Most code copied from https://github.com/rmosolgo/language-graphql/blob/master/spec/fixtures/example.graphql
 fragment on AnalysisImage @relay(plural: true) {
   extension
@@ -46,7 +66,10 @@ query
     queryName(
       $float: f = 123.011e-1, $float:  f = 123.00, $float: f = 123e+20
       $boolean: b ! = true, $boolean: b = false
-      $String: s = "Some string \" \\ \/ \b \f \r \r and the rest"
+      $String: s = """Multiline
+                   string
+                   here
+                   """
       $enum: e = aaaa, $enum: e = AAAA_AA
       $list :  [ String!, Boolean!, ID, Int, Float ] ! = ["aaa", 1 , aFlag]
       $object: o = {


### PR DESCRIPTION
Fixes #992 and fixes #993

Adds support for multiline strings for GraphQL and markdown descriptions. 

Markdown descriptions are in the GraphQL spec at https://facebook.github.io/graphql/draft/#sec-Descriptions