### PR TITLE
Install bundler 1.* to fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
   bundler: true
 bundler_args: --without development
 before_install:
-  - gem install bundler
-  - gem update --system
+  - gem install bundler --version '< 2'
+  - gem update --system '2.7.8'
 script:
   - bundle exec rake
   - bundle exec rubocop


### PR DESCRIPTION
Fixes
```
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 1.17.3. Try installing it with `gem install bundler -v 1.17.3`
	bundler requires Ruby version >= 2.3.0. The current ruby version is 2.0.0.
```