### PR TITLE
Properly highlight promoted data constructors in haskell

### DIFF
--- a/lib/rouge/lexers/haskell.rb
+++ b/lib/rouge/lexers/haskell.rb
@@ -60,7 +60,7 @@ module Rouge
         # not sure why, but ^ doesn't work here
         # rule /^[_a-z][\w']*/, Name::Function
         rule /[_a-z][\w']*/, Name
-        rule /[A-Z][\w']*/, Keyword::Type
+        rule /'?[A-Z]\w[\w']*/, Keyword::Type
 
         # lambda operator
         rule %r(\\(?![:!#\$\%&*+.\\/<=>?@^\|~-]+)), Name::Function


### PR DESCRIPTION
This is still ambiguous in the case of `'A'` but it's better than nothing.
This change is like https://github.com/jneen/rouge/pull/1027 , but just extends the current `Keyword::Type` rule